### PR TITLE
[FIX] medor_delivery_address: Let module be installable

### DIFF
--- a/medor_delivery_address/report/report_invoice.xml
+++ b/medor_delivery_address/report/report_invoice.xml
@@ -2,22 +2,19 @@
 <odoo>
 	<data>
 		<template id="report_invoice_document_inherit_sale" inherit_id="medor_sexy_invoice.theme_invoice_medor_document">
-	        <xpath expr="//div[@name='invoice_address']" position="attributes">
-	            <attribute name="groups">!sale.group_delivery_invoice_address</attribute>
-	        </xpath>
-	        <xpath expr="//div[@name='invoice_address']" position="before">
+	        <xpath expr="//address[@t-field='o.partner_id']/.." position="replace">
 	            <div class="col-xs-6" groups="sale.group_delivery_invoice_address">
-	                <div t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)">
+	                <div t-if="o.address_shipping_id and (o.address_shipping_id != o.partner_id)">
 	                    <strong>Shipping address:</strong>
-	                    <div t-field="o.partner_shipping_id"
-	                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+	                    <div t-field="o.address_shipping_id"
+	                        t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
 	                </div>
 	            </div>
-	
+
 	            <div class="col-xs-5 col-xs-offset-1" groups="sale.group_delivery_invoice_address">
 	                <div t-field="o.partner_id"
-	                    t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
-	                <div t-if="o.partner_id.vat" class="mt16"><t t-esc="o.company_id.country_id.vat_label or 'TIN'"/>: <span t-field="o.partner_id.vat"/></div>
+	                    t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+	                <div t-if="o.partner_id.vat" class="mt16">TIN: <span t-field="o.partner_id.vat"/></div>
 	            </div>
 	        </xpath>
     	</template>


### PR DESCRIPTION
Not sure what it did here… I don't understand the utility of the line:
```
<attribute name="groups">!sale.group_delivery_invoice_address</attribute>
```
It seams not to work. I understant the `!` as a negation sign but I can find other similar example.

I really don't like to do a replace in xml view. So for me a good way is to modify classes for the existing address in the sexy invoice and then add the shipping address if it is different.