### PR TITLE
[FIX] mrp_brewing : missing purchase dependency

### DIFF
--- a/mrp_brewing/__openerp__.py
+++ b/mrp_brewing/__openerp__.py
@@ -16,6 +16,7 @@
                 'sale',
                 'product',
                 'sale_order_dates',
+                'purchase',
                 ],
     'data': [
         'security/ir.model.access.csv',


### PR DESCRIPTION
'purchase' needs to be in the depends list in order to properly install mrp_brewing module on a clean install