### PR TITLE
[FIX] mrp_brewing : missing lot number for sales orders

### DIFF
--- a/mrp_brewing/models/stock.py
+++ b/mrp_brewing/models/stock.py
@@ -37,7 +37,7 @@ class StockMove(models.Model):
     def _compute_lot_numbers(self):
 
         for stock_move in self:
-            lot_numbers = stock_move.lot_numbers.split('/') if stock_move.lot_numbers else []
+            lot_numbers = []
             for qid in stock_move.quant_ids:
                 if qid.lot_id.display_name and qid.lot_id.display_name not in lot_numbers:
                     lot_numbers.append(qid.lot_id.display_name)
@@ -73,8 +73,8 @@ class StockMove(models.Model):
                         toolbar=False, submenu=False):
         result = (
             super(StockMove, self)
-            .fields_view_get(view_id, view_type,
-                             toolbar=toolbar, submenu=submenu)
+                .fields_view_get(view_id, view_type,
+                                 toolbar=toolbar, submenu=submenu)
         )
         if 'fields' in result and 'product_id' in result['fields']:
             result['fields']['product_id']['domain'] = (

--- a/mrp_brewing/report/report_stock_finished_products.xml
+++ b/mrp_brewing/report/report_stock_finished_products.xml
@@ -1,109 +1,102 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<template id="mrp_brewing.stock_finished_products">
-    <t t-call="report.html_container">
-        <t t-foreach="docs" t-as="o">
-            <t t-call="report.internal_layout">
-                <div class="page">
-                    <h2 style="text-align:center"> Finished Products Stock Report</h2>
-					<br/>
-					<h3 style="text-align:center"> Authorized warehousekeeper n°</h3>
+    <template id="mrp_brewing.stock_finished_products">
+        <t t-call="report.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-call="report.internal_layout">
+                    <div class="page">
+                        <h2 style="text-align:center">Finished Products Stock Report</h2>
+                        <br/>
+                        <h3 style="text-align:center">Authorized warehousekeeper n°</h3>
 
-                    <table class="table table-condensed">
-                        <thead>
-                            <tr>
-                                <th colspan='5'>A. Inputs</th>
-                                <th colspan='6'>B. Outputs</th>
-                                <th>C. Stock</th>
-                            </tr>
-                            <tr>
-                                <td>Date</td>
-                                <td>Lot Number</td>
-                                <td>Product</td>
-                                <td>Quantity</td>
-                                <td>UoM</td>
-                                <td>Date</td>
-                                <td>Origin</td>
-                                <td>Lot Number</td>
-                                <td>Product</td>
-                                <td>Quantity</td>
-                                <td>UoM</td>
-                                <td>Quantity left</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr t-foreach="get_stock_moves" t-as="a">
-                                <t t-if="(a.location_id.usage in ['production','inventory','inventory']) and a.location_dest_id.usage == 'internal'">
-                                   <td>
-                                        <span t-att-style="style" t-field="a.with_context(tz=a.env.user.tz).date"/>
-                                    </td>
-                                   <td>
-                                        <span t-esc="a.raw_material_production_id.brew_order_name"/>
-                                    </td>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.product_id.name" />
-                                    </td>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.product_uom_qty" />
-                                    </td>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.product_uom.name" />
-                                    </td>
-                                    <td/>
-                                    <td/>
-                                    <td/>
-                                    <td/>
-                                    <td/>
-                                    <td/>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.quantity_after_move" />
-                                    </td>
-                                </t>
-                                <t t-if="a.location_dest_id.usage in ['inventory','customer','production']">
-                                    <td/>
-                                    <td/>
-                                    <td/>
-                                    <td/>
-                                    <td/>
-                                    <td>
-                                        <span t-att-style="style" t-field="a.with_context(tz=a.env.user.tz).date" />
-                                    </td>
-                                    <td>
-                                        <span t-esc="a.origin"/>
-                                    </td>
-                                    <td>
-                                        <t t-if="a.origin">
-                                            <t t-set="lot_number" t-value="False"/>
-                                            <t t-if="a.raw_material_production_id.brew_order_name">
-                                                <t t-set="lot_number" t-value="a.raw_material_production_id.brew_order_name"/>
-                                            </t>
-                                            <t t-if="not a.raw_material_production_id.brew_order_name">
-                                                <t t-foreach="a.quant_ids" t-as="qids">
-                                                    <t t-set="lot_number" t-value="qids.lot_id.display_name"/>
+                        <table class="table table-condensed">
+                            <thead>
+                                <tr>
+                                    <th colspan='5'>A. Inputs</th>
+                                    <th colspan='6'>B. Outputs</th>
+                                    <th>C. Stock</th>
+                                </tr>
+                                <tr>
+                                    <td>Date</td>
+                                    <td>Lot Number</td>
+                                    <td>Product</td>
+                                    <td>Quantity</td>
+                                    <td>UoM</td>
+                                    <td>Date</td>
+                                    <td>Origin</td>
+                                    <td>Lot Number</td>
+                                    <td>Product</td>
+                                    <td>Quantity</td>
+                                    <td>UoM</td>
+                                    <td>Quantity left</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="get_stock_moves" t-as="a">
+                                    <t t-if="(a.location_id.usage in ['production','inventory','inventory']) and a.location_dest_id.usage == 'internal'">
+                                        <td>
+                                            <span t-att-style="style" t-field="a.with_context(tz=a.env.user.tz).date"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="a.raw_material_production_id.brew_order_name"/>
+                                        </td>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.product_id.name"/>
+                                        </td>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.product_uom_qty"/>
+                                        </td>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.product_uom.name"/>
+                                        </td>
+                                        <td/>
+                                        <td/>
+                                        <td/>
+                                        <td/>
+                                        <td/>
+                                        <td/>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.quantity_after_move"/>
+                                        </td>
+                                    </t>
+                                    <t t-if="a.location_dest_id.usage in ['inventory','customer','production']">
+                                        <td/>
+                                        <td/>
+                                        <td/>
+                                        <td/>
+                                        <td/>
+                                        <td>
+                                            <span t-att-style="style" t-field="a.with_context(tz=a.env.user.tz).date"/>
+                                        </td>
+                                        <td>
+                                            <span t-esc="a.origin"/>
+                                        </td>
+                                        <td>
+                                            <t t-if="a.origin">
+                                                <t t-if="a.lot_numbers">
+                                                    <span t-esc="a.lot_numbers"/>
                                                 </t>
                                             </t>
-                                            <span t-esc="lot_number"/>
-                                        </t>
-                                    </td>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.product_id.name" />
-                                    </td>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.product_uom_qty" />
-                                    </td>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.product_uom.name" />
-                                    </td>
-                                    <td>
-                                        <span t-att-style="style" t-esc="a.quantity_after_move" />
-                                    </td>
-                                </t>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
+                                        </td>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.product_id.name"/>
+                                        </td>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.product_uom_qty"/>
+                                        </td>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.product_uom.name"/>
+                                        </td>
+                                        <td>
+                                            <span t-att-style="style" t-esc="a.quantity_after_move"/>
+                                        </td>
+                                    </t>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </t>
             </t>
         </t>
-    </t>
-</template>
+    </template>
 </odoo>

--- a/mrp_brewing/report/report_stock_finished_products.xml
+++ b/mrp_brewing/report/report_stock_finished_products.xml
@@ -72,7 +72,18 @@
                                         <span t-esc="a.origin"/>
                                     </td>
                                     <td>
-                                        <span t-esc="a.raw_material_production_id.brew_order_name"/>
+                                        <t t-if="a.origin">
+                                            <t t-set="lot_number" t-value="False"/>
+                                            <t t-if="a.raw_material_production_id.brew_order_name">
+                                                <t t-set="lot_number" t-value="a.raw_material_production_id.brew_order_name"/>
+                                            </t>
+                                            <t t-if="not a.raw_material_production_id.brew_order_name">
+                                                <t t-foreach="a.quant_ids" t-as="qids">
+                                                    <t t-set="lot_number" t-value="qids.lot_id.display_name"/>
+                                                </t>
+                                            </t>
+                                            <span t-esc="lot_number"/>
+                                        </t>
                                     </td>
                                     <td>
                                         <span t-att-style="style" t-esc="a.product_id.name" />


### PR DESCRIPTION
Lot numbers added for sales orders lines

A lot number is provided only if : 
- there is a value for 'origin'
- there is a manufacturing order
- there is no manufacturing order but quant_ids