### PR TITLE
[ADD] This module fixes the wrong taxes amount

### DIFF
--- a/pos_order_taxes_fix/__init__.py
+++ b/pos_order_taxes_fix/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_order_taxes_fix/__manifest__.py
+++ b/pos_order_taxes_fix/__manifest__.py
@@ -1,0 +1,30 @@
+# Copyright 2019 Coop IT Easy SCRL fs
+#   Houssine BAKKALI <houssine@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': "POS orders taxes fix",
+
+    'summary': """
+        Adds a button to on pos session to fix the taxes of the orders that
+        doesn't match the calculation on backend"
+    """,
+
+    'author': "Coop IT Easy SCRL fs",
+    'website': "www.coopiteasy.be",
+
+    'category': 'Point of Sale',
+    'version': '12.0.1.0.0',
+
+    'depends': [
+        'point_of_sale',
+    ],
+
+    'data': [
+        'views/pos_session_view.xml',
+    ],
+
+    'demo': [],
+
+    'installable': True
+}

--- a/pos_order_taxes_fix/models/__init__.py
+++ b/pos_order_taxes_fix/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_session

--- a/pos_order_taxes_fix/models/pos_session.py
+++ b/pos_order_taxes_fix/models/pos_session.py
@@ -1,4 +1,7 @@
+import logging
 from odoo import api, models
+
+_logger = logging.getLogger(__name__)
 
 
 class PosSession(models.Model):
@@ -33,9 +36,9 @@ class PosSession(models.Model):
 
         taxes_diff = abs(order.amount_tax != amount_tax)
         if taxes_diff != 0:
-            print(("Taxes calculated in POS client and in backend "
-                   "don't match. There is a difference of %.2f on the "
-                   "pos order %s.") % (taxes_diff, order.name))
+            logging.info(("Taxes calculated in POS client and in backend "
+                          "don't match. There is a difference of %.2f on the "
+                          "pos order %s.") % (taxes_diff, order.name))
             order.amount_tax = amount_tax
             order.amount_total = amount_tax + amount_untaxed
 

--- a/pos_order_taxes_fix/models/pos_session.py
+++ b/pos_order_taxes_fix/models/pos_session.py
@@ -1,5 +1,4 @@
 from odoo import api, models
-from odoo.exceptions import UserError
 
 
 class PosSession(models.Model):

--- a/pos_order_taxes_fix/models/pos_session.py
+++ b/pos_order_taxes_fix/models/pos_session.py
@@ -1,0 +1,54 @@
+from odoo import api, models
+from odoo.exceptions import UserError
+
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    @api.model
+    def _amount_order_tax(self, order):
+        currency = order.pricelist_id.currency_id
+        fiscal_position = order.fiscal_position_id
+        company_id = order.company_id.id
+        partner = order.partner_id
+        group_taxes = {}
+        amount_untaxed = 0
+        for line in order.lines:
+            amount_untaxed += line.price_subtotal
+            taxes = line.tax_ids.filtered(lambda t: t.company_id.id == company_id)
+            if fiscal_position:
+                taxes = fiscal_position.map_tax(taxes,
+                                                line.product_id, partner)
+            price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
+            taxes = taxes.compute_all(price, currency, line.qty,
+                                      product=line.product_id,
+                                      partner=partner or False)['taxes']
+            for tax in taxes:
+                if group_taxes.get(tax.get('id')):
+                    group_taxes[tax.get('id')] += tax.get('amount', 0.0)
+                else:
+                    group_taxes[tax.get('id')] = tax.get('amount', 0.0)
+        amount_tax = 0.0
+        for value in group_taxes.values():
+            amount_tax += currency.round(value)
+
+        taxes_diff = abs(order.amount_tax != amount_tax)
+        if taxes_diff != 0:
+            print(("Taxes calculated in POS client and in backend "
+                   "don't match. There is a difference of %.2f on the "
+                   "pos order %s.") % (taxes_diff, order.name))
+            order.amount_tax = amount_tax
+            order.amount_total = amount_tax + amount_untaxed
+
+    @api.multi
+    def fix_pos_orders_taxes(self):
+        for session in self:
+            if session.state == "closing_control":
+                rounding_method = session.config_id.company_id.tax_calculation_rounding_method
+                orders = session.order_ids.filtered(
+                    lambda order: order.state == 'paid')
+
+                for order in orders:
+                    if rounding_method == 'round_globally':
+                        self._amount_order_tax(order)
+        return True

--- a/pos_order_taxes_fix/views/pos_session_view.xml
+++ b/pos_order_taxes_fix/views/pos_session_view.xml
@@ -1,0 +1,13 @@
+<odoo>
+    <record id="view_pos_orders_fix_form" model="ir.ui.view">
+        <field name="name">pos.session.form.view</field>
+        <field name="model">pos.session</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_session_form"/>
+        <field name="arch" type="xml">
+            <button name="action_pos_session_validate" position="after">
+                <button name="fix_pos_orders_taxes" type="object" string="Fix POS Orders Taxes Amount" states="closing_control"
+                        groups="base.group_system"/>
+            </button>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
A bug in the POS client was wrongly calculating the tax amount. The
calculation wasn't taking into account the round globally config. This
module allow the recalculation of the taxes for the problematic pos
orders of a session that can't be posted.