### PR TITLE
[9.0] foodhub  : hide terms and conditions on products

### DIFF
--- a/foodhub_custom/__openerp__.py
+++ b/foodhub_custom/__openerp__.py
@@ -19,5 +19,6 @@
 
     'data': [
         'reports/report_deliveryslip.xml',
+        'views/templates.xml',
     ],
 }

--- a/foodhub_custom/views/templates.xml
+++ b/foodhub_custom/views/templates.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <template id="hide_product_terms" inherit_id="website_sale.product" name="Hide Terms and Conditions">
+        <xpath expr="//div[@id='product_details']/p[@class='text-muted']" position="attributes">
+            <attribute name="class">hidden</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Remove element display from `website_sale`.