### PR TITLE
[9.0][ADD] sale_order_volume : pallet_nb

### DIFF
--- a/sale_order_volume/__openerp__.py
+++ b/sale_order_volume/__openerp__.py
@@ -1,40 +1,33 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2017- Coop IT Easy.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2017 - Coop IT Easy SCRLfs. (<http://www.coopiteasy.be>)
+# © 2018 - Robin Keunen <robin@coopiteasy.be>
+# © 2019 Elouan Le Bars <elouan@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 {
     "name": "Sale Order Volume",
-    "version": "1.0",
+    "version": "9.0.1.1.0",
     "depends": [
         'sale',
         'website_sale',
     ],
-    "author": "Robin Keunen <robin@coopiteasy.be>",
-    'license': 'AGPL-3',
+    "author": "Coop IT Easy SCRLfs",
     "category": "Sale",
     "website": "www.coopiteasy.be",
+    'license': 'AGPL-3',
     "description": """
-        Computes the volume of products per category ordered and display it on 
+        Computes the volume of products per category ordered and display it on
         - sale order page,
         - sale order report,
         - website shop cart website page.
+        The corresponding number of pallets is displayed on
+        - sale order page
+        - website shop cart website page.
+        Pallet volume is configurable.
     """,
     'data': [
+        'data/res_config_data.xml',
+        'views/res_config_view.xml',
         'views/sale_order.xml',
         'views/shopping_cart.xml',
         'reports/report_saleorder.xml',

--- a/sale_order_volume/data/res_config_data.xml
+++ b/sale_order_volume/data/res_config_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<openerp>
+    <data noupdate="1">
+        <record id="sale_order_volume.pallet_volume" model="ir.config_parameter">
+            <field name="key">sale_order_volume.pallet_volume</field>
+            <field name="value">1.75</field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_volume/models/__init__.py
+++ b/sale_order_volume/models/__init__.py
@@ -1,1 +1,2 @@
+from . import res_config
 from . import sale_order

--- a/sale_order_volume/models/res_config.py
+++ b/sale_order_volume/models/res_config.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, fields, models
+
+
+class SaleOrderVolumeConfiguration(models.TransientModel):
+    _inherit = "sale.config.settings"
+
+    pallet_volume = fields.Float(string="Volume of a pallet (m³)")
+
+    @api.multi
+    def set_param(self):
+        self.ensure_one()
+
+        self.env["ir.config_parameter"].set_param(
+            "sale_order_volume.pallet_volume", self.pallet_volume
+        )
+
+    @api.multi
+    def get_default_pallet_volume(self):
+        return {
+            "pallet_volume": float(
+                self.env["ir.config_parameter"].get_param(
+                    "sale_order_volume.pallet_volume"
+                )
+                or 0
+            )
+        }

--- a/sale_order_volume/models/sale_order.py
+++ b/sale_order_volume/models/sale_order.py
@@ -23,7 +23,28 @@ class ProductCategoryVolume(models.Model):
     volume = fields.Float(
         string='Volume (m³)',
     )
+    pallet_no = fields.Integer(
+        string="Number of pallets",
+        compute='compute_pallet_no'
+    )
 
+    @api.model
+    def get_pallet_volume_indication(self):
+        pallet_volume = float(self.env["ir.config_parameter"].get_param(
+        'sale_order_volume.pallet_volume'
+        )) or 0
+        return "One pallet = %.2f m³" % pallet_volume
+
+    @api.depends('volume')
+    def compute_pallet_no(self):
+        pallet_volume = float(self.env["ir.config_parameter"].get_param(
+            'sale_order_volume.pallet_volume'
+        ))
+        for product in self:
+            if pallet_volume:
+                product.pallet_no = product.volume // pallet_volume
+            else:
+                product.pallet_no = 0
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'

--- a/sale_order_volume/views/res_config_view.xml
+++ b/sale_order_volume/views/res_config_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_sales_volume_config" model="ir.ui.view">
+            <field name="name">sale volume settings</field>
+            <field name="model">sale.config.settings</field>
+            <field name="inherit_id" ref="sale.view_sales_config"/>
+            <field name="arch" type="xml">
+                <div id="main" position="inside">
+                    <group string="Volumes">
+                        <field name="pallet_volume" />
+                    </group>
+                </div>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/sale_order_volume/views/sale_order.xml
+++ b/sale_order_volume/views/sale_order.xml
@@ -11,13 +11,14 @@
                     <page string="Volume of Products">
                         <group>
                             <field name="volume"/>
+                        </group>
                             <field name="volume_per_category">
                                 <tree>
                                     <field name="category_id"/>
                                     <field name="volume"/>
+                                    <field name="pallet_no"/>
                                 </tree>
                             </field>
-                        </group>
                     </page>
                 </xpath>
             </field>

--- a/sale_order_volume/views/shopping_cart.xml
+++ b/sale_order_volume/views/shopping_cart.xml
@@ -21,6 +21,24 @@
                     </t>
                 </tbody>
             </table>
+            <h4>Number of pallets</h4>
+            <table class="table table-condensed" name="number-of-pallets">
+                <tbody class="sale_tbody">
+                    <t t-set="category_volumes"
+                       t-value="website_sale_order.compute_order_product_category_volumes()"/>
+                    <p t-esc="category_volumes[0].get_pallet_volume_indication()"/>
+                    <t t-foreach="category_volumes" t-as="line">
+                        <tr>
+                            <td>
+                                <span t-field="line.category_id"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="line.pallet_no"/>
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+            </table>
         </div>
     </template>
 


### PR DESCRIPTION
The number of pallet per category, computed from the volume of product, is displayed on the sale order and on  `website_sale`'s shopping cart. The volume of one pallet is configurable, default data is 1.75 m³.