### PR TITLE
Show again partners position

### DIFF
--- a/provelo_customization/views/res_partner_views.xml
+++ b/provelo_customization/views/res_partner_views.xml
@@ -7,10 +7,6 @@
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
 
-                <field name="function" position="attributes">
-                    <attribute name="attrs">{'invisible': 1}</attribute>
-                </field>
-
                 <field name="fax" position="attributes">
                     <attribute name="attrs">{'invisible': 1}</attribute>
                 </field>


### PR DESCRIPTION
Salut la companie,

Conformément à la tache C26 (https://gestion.coopiteasy.be/web#id=3479&view_type=form&model=project.task), voici une mini PR qui vise à restaurer la visibilité de l'attribut "Poste occupée" dans nos fiches contacts.