### PR TITLE
[ADD] provelo_customization: hide submit button and statusbar

### DIFF
--- a/provelo_customization/__openerp__.py
+++ b/provelo_customization/__openerp__.py
@@ -21,6 +21,7 @@
     "name": "Provelo Customization",
     "version": "9.0.1.0",
     "depends": [
+        'hr_timesheet_sheet',
         'resource_planning',
         'resource_activity',
     ],
@@ -32,6 +33,7 @@
         Specifics customizations for Pro Velo
     """,
     'data': [
+        'views/hr_timesheet_sheet_view.xml',
         'views/location_filters.xml',
         'views/res_partner_views.xml',
         'security/custom_security.xml',

--- a/provelo_customization/views/hr_timesheet_sheet_view.xml
+++ b/provelo_customization/views/hr_timesheet_sheet_view.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="hr_timesheet_sheet_form" model="ir.ui.view">
+            <field name="name">hr.timesheet.sheet.form</field>
+            <field name="model">hr_timesheet_sheet.sheet</field>
+            <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
+            <field name="arch" type="xml">
+                <!--
+                    Replacing `states` with `attrs` since using the first in combination with the second
+                    may lead to unexpected results as domains are combined with a logical AND. (from doc)
+                -->
+                <button name="button_confirm" position="replace">
+                    <button name="button_confirm" attrs="{'invisible': True}" string="Submit to Manager" type="object" class="oe_highlight"/>
+                </button>
+                <button name="done" position="replace">
+                    <button name="done" attrs="{'invisible': True}" string="Approve" type="workflow" groups="base.group_hr_user" class="oe_highlight"/>
+                </button>
+                <button name="action_set_to_draft" position="replace">
+                    <button name="action_set_to_draft" attrs="{'invisible': True}" string="Set to Draft" type="object" />
+                </button>
+                <button name="cancel" position="replace">
+                    <button name="cancel" attrs="{'invisible': True}" string="Refuse" type="workflow" groups="base.group_hr_user" />
+                </button>
+
+                <field name="state" position="replace">
+                    <field name="state" invisible="1"/>
+                </field>
+
+            </field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
Demande initiale de Pro Velo quant aux feuilles de temps: 

> vu qu'on ne travaillerait pas avec validation par le responsable, il semble inutile de bombarder celui-ci de mails à chaque complétion d'une feuille de temps. Voire même il faudrait cacher le bouton "Soumettre au responsable", ainsi que tout le bandeau de processus de validation.

