### PR TITLE
Expand Certisys labeling

### DIFF
--- a/account_invoice_label_certisys/__openerp__.py
+++ b/account_invoice_label_certisys/__openerp__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Invoice label certisys',
-    'description': 'Add certisys label on invoices',
+    'description': 'Add Certisys label on invoices, delivery slips and picking opperations (stock picking), and sale orders',
     'category': 'Invoice',
     'version': '9.0.1.0',
     'author': 'Coop IT Easy SCRLfs',
@@ -27,7 +27,9 @@
         'account',
         ],
     'data': [
-        'reports/invoice_template.xml'
+        'reports/invoice_template.xml',
+        'reports/stock_template.xml',
+        'reports/sale_template.xml'
     ],
     'installable': True,
 }

--- a/account_invoice_label_certisys/__openerp__.py
+++ b/account_invoice_label_certisys/__openerp__.py
@@ -1,30 +1,19 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2013-2016 Open Architects Consulting SPRL.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2013-2019 Coop IT Easy SCRLfs
+#     - Houssine Bakkali <houssine@coopiteasy.be>
+#     - Manuel Claeys Bouuaert <manuel@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Account Invoice label certisys',
     'description': 'Add Certisys label on invoices, delivery slips and picking opperations (stock picking), and sale orders. This module should get a more generic name in the future.',
     'category': 'Invoice',
-    'version': '9.0.1.0',
+    'version': '9.0.1.1',
     'author': 'Coop IT Easy SCRLfs',
+    "website": "https://coopiteasy.be",
     'depends': [
         'account',
+        'stock',
+        'sale',
         ],
     'data': [
         'reports/invoice_template.xml',

--- a/account_invoice_label_certisys/__openerp__.py
+++ b/account_invoice_label_certisys/__openerp__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Invoice label certisys',
-    'description': 'Add Certisys label on invoices, delivery slips and picking opperations (stock picking), and sale orders',
+    'description': 'Add Certisys label on invoices, delivery slips and picking opperations (stock picking), and sale orders. This module should get a more generic name in the future.',
     'category': 'Invoice',
     'version': '9.0.1.0',
     'author': 'Coop IT Easy SCRLfs',

--- a/account_invoice_label_certisys/i18n/fr_BE.po
+++ b/account_invoice_label_certisys/i18n/fr_BE.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_label_certisys
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-01-08 11:07+0000\n"
+"PO-Revision-Date: 2020-01-08 11:07+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_label_certisys
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_account_invoice_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_report_picking
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_sale_saleorder_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_stock_delivery_document
+msgid "All products of"
+msgstr "Tous les produits de"
+
+#. module: account_invoice_label_certisys
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_account_invoice_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_report_picking
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_sale_saleorder_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_stock_delivery_document
+msgid "are certified BIO by Certisys BE-BIO-01"
+msgstr "sont certifiées BIO par Certisys BE-BIO-01"
+

--- a/account_invoice_label_certisys/i18n/nl_BE.po
+++ b/account_invoice_label_certisys/i18n/nl_BE.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_label_certisys
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-01-08 11:09+0000\n"
+"PO-Revision-Date: 2020-01-08 11:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_label_certisys
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_account_invoice_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_report_picking
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_sale_saleorder_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_stock_delivery_document
+msgid "All products of"
+msgstr "Alle producten van"
+
+#. module: account_invoice_label_certisys
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_account_invoice_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_report_picking
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_sale_saleorder_document
+#: model:ir.ui.view,arch_db:account_invoice_label_certisys.certicys_label_stock_delivery_document
+msgid "are certified BIO by Certisys BE-BIO-01"
+msgstr "zijn BIO gecertificeerd door Certisys BE-BIO-01"
+

--- a/account_invoice_label_certisys/reports/invoice_template.xml
+++ b/account_invoice_label_certisys/reports/invoice_template.xml
@@ -5,7 +5,7 @@
 		<xpath expr="//p[@t-if='o.fiscal_position_id.note']" position="after">
 			<p>
                 <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
-                <strong>Tous les produits de la <span t-field="o.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
+                <strong>All products of <span t-field="o.company_id.name"/> are certified BIO by Certisys BE-BIO-01</strong>
             </p>
 		</xpath>
 		

--- a/account_invoice_label_certisys/reports/invoice_template.xml
+++ b/account_invoice_label_certisys/reports/invoice_template.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 <data>
-	<template id="certicys_label" inherit_id="account.report_invoice_document">
+	<template id="certicys_label_account_invoice_document" inherit_id="account.report_invoice_document">
 		<xpath expr="//p[@t-if='o.fiscal_position_id.note']" position="after">
 			<p>
                 <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
-                <strong>Toutes les bières de la <span t-field="o.company_id.name"/> sont certifiées bio par certisys BE-BIO-01</strong>
+                <strong>Tous les produits de la <span t-field="o.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
             </p>
 		</xpath>
 		

--- a/account_invoice_label_certisys/reports/sale_template.xml
+++ b/account_invoice_label_certisys/reports/sale_template.xml
@@ -5,7 +5,7 @@
 		<xpath expr="//p[@id='fiscal_position_remark']" position="after">
 			<p>
                 <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
-                <strong>Tous les produits de la <span t-field="doc.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
+                <strong>All products of <span t-field="doc.company_id.name"/> are certified BIO by Certisys BE-BIO-01</strong>
             </p>
 		</xpath>
 		

--- a/account_invoice_label_certisys/reports/sale_template.xml
+++ b/account_invoice_label_certisys/reports/sale_template.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data>
+	<template id="certicys_label_sale_saleorder_document" inherit_id="sale.report_saleorder_document">
+		<xpath expr="//p[@id='fiscal_position_remark']" position="after">
+			<p>
+                <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
+                <strong>Tous les produits de la <span t-field="doc.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
+            </p>
+		</xpath>
+		
+	</template>
+</data>
+</odoo>

--- a/account_invoice_label_certisys/reports/stock_template.xml
+++ b/account_invoice_label_certisys/reports/stock_template.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data>
+	<template id="certicys_label_report_picking" inherit_id="stock.report_picking">
+		<xpath expr="//p[@t-if='not o.pack_operation_ids']" position="after">
+			<p>
+                <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
+                <strong>Tous les produits de la <span t-field="o.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
+            </p>
+		</xpath>
+		
+	</template>
+
+	<template id="certicys_label_stock_delivery_document" inherit_id="stock.report_delivery_document">
+		<xpath expr="//table[@t-if='o.pack_operation_ids']" position="after">
+			<p>
+                <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
+                <strong>Tous les produits de la <span t-field="o.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
+            </p>
+		</xpath>
+
+	</template>
+</data>
+</odoo>

--- a/account_invoice_label_certisys/reports/stock_template.xml
+++ b/account_invoice_label_certisys/reports/stock_template.xml
@@ -5,7 +5,7 @@
 		<xpath expr="//p[@t-if='not o.pack_operation_ids']" position="after">
 			<p>
                 <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
-                <strong>Tous les produits de la <span t-field="o.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
+                <strong>All products of <span t-field="o.company_id.name"/> are certified BIO by Certisys BE-BIO-01</strong>
             </p>
 		</xpath>
 		
@@ -15,7 +15,7 @@
 		<xpath expr="//table[@t-if='o.pack_operation_ids']" position="after">
 			<p>
                 <img src="/account_invoice_label_certisys/static/img/EU_Organic_Logo.jpg" style="width:98px;height:auto;padding-bottom:5px;"/>
-                <strong>Tous les produits de la <span t-field="o.company_id.name"/> sont certifiées bio par Certisys BE-BIO-01</strong>
+                <strong>All products of <span t-field="o.company_id.name"/> are certified BIO by Certisys BE-BIO-01</strong>
             </p>
 		</xpath>
 


### PR DESCRIPTION
This PR adds Certisys labeling to delivery slips and picking opperations (stock picking), and sale orders. It also puts standard text in english and provides translation to dutch and french.