### PR TITLE
[9.0] provelo rh-13 : hide current_leave_id in hr_kanban_view_employees

### DIFF
--- a/provelo_customization/__openerp__.py
+++ b/provelo_customization/__openerp__.py
@@ -21,11 +21,11 @@
     "name": "Provelo Customization",
     "version": "9.0.1.0",
     "depends": [
-        'hr_holidays',
-        'hr_timesheet_sheet',
-        'resource_planning',
-        'resource_activity',
-        'web_readonly_bypass',
+        "hr_holidays",
+        "hr_timesheet_sheet",
+        "resource_planning",
+        "resource_activity",
+        "web_readonly_bypass",
     ],
     "author": "Coop IT Easy - Robin Keunen <robin@coopiteasy.be>",
     "license": "AGPL-3",
@@ -34,13 +34,13 @@
     "description": """
         Specifics customizations for Pro Velo
     """,
-    'data': [
-        'views/hr_holidays_view.xml',
-        'views/hr_timesheet_sheet_view.xml',
-        'views/location_filters.xml',
-        'views/res_partner_views.xml',
-        'security/security.xml',
-        'security/ir.model.access.csv',
+    "data": [
+        "views/hr_holidays_view.xml",
+        "views/hr_timesheet_sheet_view.xml",
+        "views/location_filters.xml",
+        "views/res_partner_views.xml",
+        "security/security.xml",
+        "security/ir.model.access.csv",
     ],
-    'installable': True,
+    "installable": True,
 }

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -19,7 +19,7 @@
             <field name="inherit_id" ref="hr_holidays.hr_kanban_view_employees_kanban"/>
             <field name="arch" type="xml">
 
-                <xpath expr="//li[@id='last_login']/field[@name='current_leave_id']" position="attributes">
+                <xpath expr="//li[@id='last_login']//field[@name='current_leave_id']" position="attributes">
                     <attribute name="invisible">True</attribute>
                 </xpath>
 

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -13,5 +13,16 @@
             </field>
         </record>
 
+        <record model="ir.ui.view" id="hr_kanban_view_employees_kanban_inherited">
+            <field name="name">HR - hide current_leave_id</field>
+            <field name="model">hr.employee</field>
+            <field name="inherit_id" ref="hr_holidays.hr_kanban_view_employees_kanban"/>
+            <field name="arch" type="xml">
+                <field name="current_leave_id" position="attributes">
+                    <attribute name="invisible">True</attribute>
+                </field>
+            </field>
+        </record>
+
     </data>
 </odoo>

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -18,9 +18,11 @@
             <field name="model">hr.employee</field>
             <field name="inherit_id" ref="hr_holidays.hr_kanban_view_employees_kanban"/>
             <field name="arch" type="xml">
-                <field name="current_leave_id" position="attributes">
+
+                <xpath expr="//li[@id='last_login']/field[@name='current_leave_id']" position="attributes">
                     <attribute name="invisible">True</attribute>
-                </field>
+                </xpath>
+
             </field>
         </record>
 


### PR DESCRIPTION
Client's need : 
> empêcher de voir la raison de l'absence sur la fiche employée : soit voir "absence" ; soit rien 


