### PR TITLE
[9.0][ADD] provelo_custom: domain to only show unarchived analytic accounts

### DIFF
--- a/provelo_customization/__openerp__.py
+++ b/provelo_customization/__openerp__.py
@@ -37,6 +37,7 @@
     'data': [
         'views/hr_holidays_view.xml',
         'views/hr_timesheet_sheet_view.xml',
+        'views/hr_timesheet_view.xml',
         'views/location_filters.xml',
         'views/res_partner_views.xml',
         'security/security.xml',

--- a/provelo_customization/views/hr_timesheet_sheet_view.xml
+++ b/provelo_customization/views/hr_timesheet_sheet_view.xml
@@ -28,8 +28,21 @@
                     <field name="state" invisible="1"/>
                 </field>
 
+                <!--
+                    Hide archived analytic accounts
+                -->
+                <xpath expr="//notebook//tree/field[@name='account_id']" position="attributes">
+                    <attribute name="domain">[('account_type','=','normal')]</attribute>
+                </xpath>
+
+                <xpath expr="//notebook//form//field[@name='account_id']" position="attributes">
+                    <attribute name="domain">[('account_type','=','normal')]</attribute>
+                </xpath>
+
             </field>
         </record>
+
+
 
     </data>
 </odoo>

--- a/provelo_customization/views/hr_timesheet_view.xml
+++ b/provelo_customization/views/hr_timesheet_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="hr_timesheet_line_tree" model="ir.ui.view">
+            <field name="name">account.analytic.line.tree</field>
+            <field name="model">account.analytic.line</field>
+            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
+            <field name="arch" type="xml">
+                <!--
+                    Hide archived analytic accounts
+                -->
+                <field name="account_id" position="attributes">
+                    <attribute name="domain">[('account_type','=','normal')]</attribute>
+                </field>
+
+            </field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
**Before:**
Archived (`state=closed`) analytic accounts appear in Timesheets views.

**After:**
Only _unarchived_ (`state=normal`) analytic accounts appear.

**Modified records:**
- hr_timesheet_view: for 'Timesheets' > 'Activities' view
- hr_timesheet_sheet_view: for 'Details' Tab view

Thanks to @provelo-ict for pointing out the domain to use !