### PR TITLE
[9.0][ADD] provelo_customization: hr_holidays leaves record rules

### DIFF
--- a/provelo_customization/security/security.xml
+++ b/provelo_customization/security/security.xml
@@ -15,7 +15,7 @@
         <record id="hr_employee_own_account_analytic_line" model="ir.rule">
             <field name="name">hr_employee_own_account_analytic_line</field>
             <field name="model_id" ref="account.model_account_analytic_line"/>
-            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -24,9 +24,9 @@
         </record>
 
         <record id="department_manager_department_account_analytic_line" model="ir.rule">
-            <field name="name">department_manager_depatment_account_analytic_line</field>
+            <field name="name">department_manager_department_account_analytic_line</field>
             <field name="model_id" ref="account.model_account_analytic_line"/>
-            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -40,7 +40,7 @@
         <record id="hr_manager_all_account_analytic_line" model="ir.rule">
             <field name="name">hr_manager_all_account_analytic_line</field>
             <field name="model_id" ref="account.model_account_analytic_line"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_manager'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -62,7 +62,7 @@
         <record id="hr_employee_own_leaves" model="ir.rule">
             <field name="name">hr_employee_own_leaves</field>
             <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
-            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -73,7 +73,7 @@
         <record id="department_manager_department_leaves" model="ir.rule">
             <field name="name">department_manager_department_leaves</field>
             <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
-            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -87,7 +87,7 @@
         <record id="hr_manager_all_leaves" model="ir.rule">
             <field name="name">hr_manager_all_leaves</field>
             <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_manager'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>

--- a/provelo_customization/security/security.xml
+++ b/provelo_customization/security/security.xml
@@ -11,40 +11,89 @@
             <field name="category_id" ref="base.module_category_usability"/>
         </record>
 
-         <record id="hr_employee_own_account_analytic_line" model="ir.rule">
-             <field name="name">hr_employee_own_account_analytic_line</field>
-             <field name="model_id" ref="account.model_account_analytic_line"/>
-             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
-             <field name="perm_read" eval="1"/>
-             <field name="perm_write" eval="1"/>
-             <field name="perm_create" eval="1"/>
-             <field name="perm_unlink" eval="1"/>
-             <field name="domain_force">[('user_id','=',user.id)]</field>
-         </record>
+        <!-- Account Analityc Lines -->
+        <record id="hr_employee_own_account_analytic_line" model="ir.rule">
+            <field name="name">hr_employee_own_account_analytic_line</field>
+            <field name="model_id" ref="account.model_account_analytic_line"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+            <field name="domain_force">[('user_id','=',user.id)]</field>
+        </record>
 
-         <record id="deparment_manager_department_account_analytic_line" model="ir.rule">
-             <field name="name">deparment_manager_depatment_account_analytic_line</field>
-             <field name="model_id" ref="account.model_account_analytic_line"/>
-             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
-             <field name="perm_read" eval="1"/>
-             <field name="perm_write" eval="1"/>
-             <field name="perm_create" eval="1"/>
-             <field name="perm_unlink" eval="1"/>
-             <field name="domain_force">[
-                 ('user_id.employee_ids.parent_id', '=', user.employee_ids.id)
-             ]</field>
-         </record>
+        <record id="deparment_manager_department_account_analytic_line" model="ir.rule">
+            <field name="name">deparment_manager_depatment_account_analytic_line</field>
+            <field name="model_id" ref="account.model_account_analytic_line"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+            <field name="domain_force">[
+                ('user_id.employee_ids.parent_id', '=', user.employee_ids.id)
+                ]
+            </field>
+        </record>
 
-         <record id="hr_manager_all_account_analytic_line" model="ir.rule">
-             <field name="name">hr_manager_all_account_analytic_line</field>
-             <field name="model_id" ref="account.model_account_analytic_line"/>
-             <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
-             <field name="perm_read" eval="1"/>
-             <field name="perm_write" eval="1"/>
-             <field name="perm_create" eval="1"/>
-             <field name="perm_unlink" eval="1"/>
-             <field name="domain_force">[(1, '=', 1)]</field>
-         </record>
+        <record id="hr_manager_all_account_analytic_line" model="ir.rule">
+            <field name="name">hr_manager_all_account_analytic_line</field>
+            <field name="model_id" ref="account.model_account_analytic_line"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+        </record>
+
+        <!-- Account Analityc Lines -->
+
+        <!-- deactivate standard rules -->
+        <record id="hr_holidays.property_rule_holidays_employee" model="ir.rule">
+            <field name="active" eval="False"/>
+        </record>
+
+        <record id="hr_holidays.property_rule_holidays_employee_write" model="ir.rule">
+            <field name="active" eval="False"/>
+        </record>
+
+        <record id="hr_employee_own_leaves" model="ir.rule">
+            <field name="name">hr_employee_own_leaves</field>
+            <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+            <field name="domain_force">[('user_id','=',user.id)]</field>
+        </record>
+
+        <record id="deparment_manager_department_leaves" model="ir.rule">
+            <field name="name">deparment_manager_department_leaves</field>
+            <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+            <field name="domain_force">[
+                ('user_id.employee_ids.parent_id', '=', user.employee_ids.id)
+                ]
+            </field>
+        </record>
+
+        <record id="hr_manager_all_leaves" model="ir.rule">
+            <field name="name">hr_manager_all_leaves</field>
+            <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+        </record>
 
     </data>
 </openerp>

--- a/provelo_customization/security/security.xml
+++ b/provelo_customization/security/security.xml
@@ -15,7 +15,7 @@
         <record id="hr_employee_own_account_analytic_line" model="ir.rule">
             <field name="name">hr_employee_own_account_analytic_line</field>
             <field name="model_id" ref="account.model_account_analytic_line"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -26,7 +26,7 @@
         <record id="department_manager_department_account_analytic_line" model="ir.rule">
             <field name="name">department_manager_department_account_analytic_line</field>
             <field name="model_id" ref="account.model_account_analytic_line"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -37,10 +37,10 @@
             </field>
         </record>
 
-        <record id="hr_manager_all_account_analytic_line" model="ir.rule">
-            <field name="name">hr_manager_all_account_analytic_line</field>
+        <record id="hr_officer_all_account_analytic_line" model="ir.rule">
+            <field name="name">hr_officer_all_account_analytic_line</field>
             <field name="model_id" ref="account.model_account_analytic_line"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_manager'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -62,7 +62,7 @@
         <record id="hr_employee_own_leaves" model="ir.rule">
             <field name="name">hr_employee_own_leaves</field>
             <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -73,7 +73,7 @@
         <record id="department_manager_department_leaves" model="ir.rule">
             <field name="name">department_manager_department_leaves</field>
             <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
@@ -84,10 +84,10 @@
             </field>
         </record>
 
-        <record id="hr_manager_all_leaves" model="ir.rule">
-            <field name="name">hr_manager_all_leaves</field>
+        <record id="hr_officer_all_leaves" model="ir.rule">
+            <field name="name">hr_officer_all_leaves</field>
             <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_manager'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_user'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>

--- a/provelo_customization/security/security.xml
+++ b/provelo_customization/security/security.xml
@@ -23,8 +23,8 @@
             <field name="domain_force">[('user_id','=',user.id)]</field>
         </record>
 
-        <record id="deparment_manager_department_account_analytic_line" model="ir.rule">
-            <field name="name">deparment_manager_depatment_account_analytic_line</field>
+        <record id="department_manager_department_account_analytic_line" model="ir.rule">
+            <field name="name">department_manager_depatment_account_analytic_line</field>
             <field name="model_id" ref="account.model_account_analytic_line"/>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="1"/>
@@ -70,8 +70,8 @@
             <field name="domain_force">[('user_id','=',user.id)]</field>
         </record>
 
-        <record id="deparment_manager_department_leaves" model="ir.rule">
-            <field name="name">deparment_manager_department_leaves</field>
+        <record id="department_manager_department_leaves" model="ir.rule">
+            <field name="name">department_manager_department_leaves</field>
             <field name="model_id" ref="hr_holidays.model_hr_holidays"/>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="1"/>


### PR DESCRIPTION
**Before**
- an _Employee_ could see other employees' leaves

**After**
- an _Employee_ can only see its own leaves
- a _Department Manager_ can only see both its employees' leaves and own leaves
- a _HR Manager_ can see all leaves

Thanks @robinkeunen for the help !