### PR TITLE
[9.0][ADD] provelo_customization : 'Allocation Request' submenu restrictions

### DIFF
--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -26,9 +26,9 @@
             </field>
         </record>
 
-        <menuitem parent="menu_hr_holidays_my_leaves"
+        <menuitem parent="hr_holidays.menu_hr_holidays_my_leaves"
                   id="menu_open_allocation_holidays"
-                  action="open_allocation_holidays"
+                  action="hr_holidays.open_allocation_holidays"
                   sequence="40"
                   groups="base.group_hr_manager"/>
 

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -29,7 +29,7 @@
         <record model="ir.ui.menu" id="menu_hr_holidays_my_leaves">
             <field name="name">HR - hide 'Allocation Request' menu to employees</field>
             <field name="model">hr.holidays</field>
-            <field name="inherit_id" ref="menu_open_allocation_holidays"/>
+            <field name="inherit_id" ref="hr_holidays.menu_open_allocation_holidays"/>
             <field name="groups" eval="[(4, ref('base.group_hr_manager'))]"/>
         </record>
 

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -5,10 +5,10 @@
         <record model="ir.actions.act_window" id="hr_holidays.action_hr_holidays_dashboard">
             <field name="context">
                 {
-                    'search_default_year': 1,
-                    'search_default_group_employee': 1,
-                    'search_default_my_leaves': 1,
-                    'readonly_by_pass': True,
+                'search_default_year': 1,
+                'search_default_group_employee': 1,
+                'search_default_my_leaves': 1,
+                'readonly_by_pass': True,
                 }
             </field>
         </record>
@@ -24,6 +24,13 @@
                 </xpath>
 
             </field>
+        </record>
+
+        <record model="ir.ui.menu" id="menu_hr_holidays_my_leaves">
+            <field name="name">HR - hide 'Allocation Request' menu to employees</field>
+            <field name="model">hr.holidays</field>
+            <field name="inherit_id" ref="menu_open_allocation_holidays"/>
+            <field name="groups" eval="[(4, ref('base.group_hr_manager'))]"/>
         </record>
 
     </data>

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -27,9 +27,6 @@
         </record>
 
         <record model="ir.ui.menu" id="menu_hr_holidays_my_leaves">
-            <field name="name">HR - hide 'Allocation Request' menu to employees</field>
-            <field name="model">hr.holidays</field>
-            <field name="inherit_id" ref="hr_holidays.menu_open_allocation_holidays"/>
             <field name="groups_id" eval="[(4, ref('base.group_hr_manager'))]"/>
         </record>
 

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -30,7 +30,7 @@
             <field name="name">HR - hide 'Allocation Request' menu to employees</field>
             <field name="model">hr.holidays</field>
             <field name="inherit_id" ref="hr_holidays.menu_open_allocation_holidays"/>
-            <field name="groups" eval="[(4, ref('base.group_hr_manager'))]"/>
+            <field name="groups_id" eval="[(4, ref('base.group_hr_manager'))]"/>
         </record>
 
     </data>

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -27,9 +27,8 @@
         </record>
 
         <menuitem parent="hr_holidays.menu_hr_holidays_my_leaves"
-                  id="menu_open_allocation_holidays"
+                  id="hr_holidays.menu_open_allocation_holidays"
                   action="hr_holidays.open_allocation_holidays"
-                  sequence="40"
                   groups="base.group_hr_manager"/>
 
     </data>

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -29,7 +29,8 @@
         <menuitem parent="hr_holidays.menu_hr_holidays_my_leaves"
                   id="hr_holidays.menu_open_allocation_holidays"
                   action="hr_holidays.open_allocation_holidays"
-                  groups="base.group_hr_manager"/>
+                  groups="base.group_hr_manager"
+                  sequence="40"/>
 
     </data>
 </odoo>

--- a/provelo_customization/views/hr_holidays_view.xml
+++ b/provelo_customization/views/hr_holidays_view.xml
@@ -26,9 +26,11 @@
             </field>
         </record>
 
-        <record model="ir.ui.menu" id="menu_hr_holidays_my_leaves">
-            <field name="groups_id" eval="[(4, ref('base.group_hr_manager'))]"/>
-        </record>
+        <menuitem parent="menu_hr_holidays_my_leaves"
+                  id="menu_open_allocation_holidays"
+                  action="open_allocation_holidays"
+                  sequence="40"
+                  groups="base.group_hr_manager"/>
 
     </data>
 </odoo>


### PR DESCRIPTION
**Before**
Allocation Request submenu was visible by anyone

**After**
Only _HR Managers_ can see/use this submenu