### PR TITLE
[FIX] hr_holidays_half_day: period field -> required

### DIFF
--- a/hr_holidays_half_day/models/hr_holidays.py
+++ b/hr_holidays_half_day/models/hr_holidays.py
@@ -20,7 +20,7 @@ class HrHolidays(models.Model):
     period = fields.Selection(
         string="Period",
         selection=[("am", "AM"), ("pm", "PM"), ("day", "Day")],
-        default="day",
+        required=True,
     )
 
     @api.multi
@@ -61,7 +61,7 @@ class HrHolidays(models.Model):
                 from_dt, to_dt = self._replace_duration(
                     from_dt, to_dt, company.pm_hour_from, company.pm_hour_to
                 )
-            else:
+            elif period == "day":
                 from_dt, to_dt = self._replace_duration(
                     from_dt, to_dt, company.am_hour_from, company.pm_hour_to
                 )


### PR DESCRIPTION
### [Task](https://gestion.coopiteasy.be/web#id=4342&view_type=form&model=project.task&action=475&active_id=98)

### Changes
- removed `default` value on field `period`
- added `required` argument on field `period`
- more specific conditional argument : `else` -> `elif period == 'day'`