### PR TITLE
[FIX] email_template_config: new variables in v12

### DIFF
--- a/email_template_config/models/mail_template.py
+++ b/email_template_config/models/mail_template.py
@@ -7,8 +7,10 @@ class MailTemplate(models.Model):
     force_email_send = fields.Boolean(string="Force mail send?")
 
     @api.multi
-    def send_mail(self, res_id, force_send=False, raise_exception=False):
+    def send_mail(self, res_id, force_send=False, raise_exception=False, email_values=None, notif_layout=False):
         return super(MailTemplate, self).send_mail(
                                             res_id,
                                             force_send=self.force_email_send,
-                                            raise_exception=False)
+                                            raise_exception=raise_exception,
+                                            email_values=email_values,
+                                            notif_layout=notif_layout)


### PR DESCRIPTION
These were forgotten in the port to v12. This gave errors `send_mail() receives unexpected variable email_values` when the `send_email()` function was used with one of it's two new variables.