### PR TITLE
[12.0][FIX] stock_[provider_ref|product_weight]_on_receipt: xpath expr

### DIFF
--- a/stock_product_weight_on_receipt/reports/report_deliveryslip.xml
+++ b/stock_product_weight_on_receipt/reports/report_deliveryslip.xml
@@ -5,28 +5,28 @@
               name="Receipt with weight">
 
         <!-- t-if="o.state!='done'" -->
-        <xpath expr="//table[2]//th//*[contains(text(),'Product')]" position="after">
-            <th>
+        <xpath expr="//table[2]//th[1]" position="after">
+            <th name="weight">
                 <strong>Weight</strong>
             </th>
         </xpath>
 
         <xpath expr="//table[2]//td/span[@t-field='move.product_id']/parent::td" position="after">
-            <td>
+            <td name="weight">
                 <span t-field="move.display_weight"/>
                 <span t-field="move.display_unit"/>
             </td>
         </xpath>
 
         <!-- t-if="o.move_line_ids and o.state=='done'" -->
-        <xpath expr="//table[3]//th//*[contains(text(),'Product')]" position="after">
-            <th class="text-center">
+        <xpath expr="//table[3]//th[1]" position="after">
+            <th name="weight" class="text-center">
                 <strong>Weight</strong>
             </th>
         </xpath>
 
         <xpath expr="//table[3]//td/span[@t-field='move_line.product_id']/parent::td" position="after">
-            <td class="text-center">
+            <td name="weight" class="text-center">
                 <span t-field="move_line.display_weight"/>
                 <span t-field="move_line.display_unit"/>
             </td>

--- a/stock_provider_ref_on_receipt/reports/report_deliveryslip.xml
+++ b/stock_provider_ref_on_receipt/reports/report_deliveryslip.xml
@@ -5,27 +5,27 @@
               name="Receipt with provider reference">
 
         <!-- t-if="o.state!='done'" -->
-        <xpath expr="//table[2]//th//*[contains(text(),'Product')]" position="after">
-            <th>
+        <xpath expr="//table[2]//th[1]" position="after">
+            <th name="provider_ref">
                 <strong>Provider ref.</strong>
             </th>
         </xpath>
 
         <xpath expr="//table[2]//td/span[@t-field='move.product_id']/parent::td" position="after">
-            <td>
+            <td name="provider_ref">
                 <span t-field="move.provider_ref"/>
             </td>
         </xpath>
 
         <!-- t-if="o.move_line_ids and o.state=='done'" -->
-        <xpath expr="//table[3]//th//*[contains(text(),'Product')]" position="after">
-            <th class="text-left">
+        <xpath expr="//table[3]//th[1]" position="after">
+            <th name="provider_ref" class="text-left">
                 <span>Provider ref.</span>
             </th>
         </xpath>
 
         <xpath expr="//table[3]//td/span[@t-field='move_line.product_id']/parent::td" position="after">
-            <td class="text-left">
+            <td name="provider_ref" class="text-left">
                 <span t-field="move_line.provider_ref"/>
             </td>
         </xpath>


### PR DESCRIPTION
#### [Task](https://gestion.coopiteasy.be/web#id=3140&view_type=form&model=project.task)
Previous xpath expression fails if database language is not english.