### PR TITLE
[9.0][FIX] hr_holidays_half_day: default period for allocation requests

### DIFF
--- a/hr_holidays_half_day/models/hr_holidays.py
+++ b/hr_holidays_half_day/models/hr_holidays.py
@@ -21,6 +21,8 @@ class HrHolidays(models.Model):
         string="Period",
         selection=[("am", "AM"), ("pm", "PM"), ("day", "Day")],
         required=True,
+        readonly=True,
+        states={'draft':[('readonly',False)], 'confirm':[('readonly',False)]}
     )
 
     @api.multi

--- a/hr_holidays_half_day/views/hr_holidays_view.xml
+++ b/hr_holidays_half_day/views/hr_holidays_view.xml
@@ -17,10 +17,10 @@
                     <attribute name="readonly">1</attribute>
                 </field>
                 <field name="number_of_days_temp" position="attributes">
-                    <attribute name="attrs">{'readonly':[('type', '=', 'remove'),('state','!=','draft')]}</attribute>
+                    <attribute name="attrs">{'readonly':['|',('state','not in',['draft','confirm']), ('type','=','remove')]}</attribute>
                 </field>
                 <xpath expr="//sheet/group/group[1]" position="inside">
-                    <field name="period" widget="radio" context="{'employee_id': employee_id}" attrs="{'readonly':[('state','!=','draft'), ('type', '=', 'add')], 'invisible':[('type', '=', 'add')]}"/>
+                    <field name="period" widget="radio" context="{'employee_id': employee_id}" attrs="{'invisible':[('type', '=', 'add')]}"/>
                 </xpath>
             </field>
         </record>
@@ -104,6 +104,7 @@
         <record model="ir.actions.act_window" id="hr_holidays.open_allocation_holidays">
             <field name="context">{
                 'default_type':'add',
+                'default_period': 'day',
                 'search_default_my_leaves':1,
                 'needaction_menu_ref':
                 [
@@ -124,6 +125,16 @@
                 ],
                 'readonly_by_pass': ['date_from', 'date_to', 'number_of_days_temp'],
             }</field>
+        </record>
+
+        <record model="ir.actions.act_window" id="hr_holidays.open_department_holidays_allocation_approve">
+            <field name="context">{
+                'default_type':'add',
+                'default_period': 'day',
+                'search_default_department':1,
+                'search_default_approve':1
+                }
+            </field>
         </record>
 
     </data>


### PR DESCRIPTION
#### [Task](https://gestion.coopiteasy.be/web#id=4655&view_type=form&model=project.task&action=479)
Fix the following error when saving/approving an allocation request:
```
L'opération n'a pas pu être complétée, probablement à la suite d'une :
- suppression : vous essayez de supprimer un enregistrement auquel d'autres enregistrements font référence
- création/modification : un champ requis n'est pas correctement rempli

[objet référencé : period - period]
```
![screenshot-gestion provelo org-2020 05 26-15_55_42](https://user-images.githubusercontent.com/28013700/83023553-56e45b00-a02d-11ea-81c0-c058f5f5cda8.png)

This is due to the fact that
1) `period` is a required field and a default value prevents a correct computing of `_compute_number_of_days_from_contract`
2) `period` is hidden on the allocation request view

The workaround is to provide a default value through the `ir.actions.act_window` `context`.