### PR TITLE
[FIX] mrp_bom_version: only increment boms for same product

### DIFF
--- a/mrp_bom_version/__openerp__.py
+++ b/mrp_bom_version/__openerp__.py
@@ -8,7 +8,7 @@
     "name": "MRP - BoM version",
     "summary": "BoM versioning",
     'description': "This module provides a state in the BoM whether to allow their use in manufacturing.",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "license": "AGPL-3",
     "author": "OdooMRP team,"
               "AvanzOSC,"

--- a/mrp_bom_version/models/mrp_bom.py
+++ b/mrp_bom_version/models/mrp_bom.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Oihane Crucelaegui - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-import openerp.addons.decimal_precision as dp
+from openerp.addons.decimal_precision import decimal_precision as dp
 
 from openerp import models, fields, api
 from openerp.tools import config
@@ -120,7 +120,7 @@ class MrpBom(models.Model):
             'res_id': new_bom.id,
             'target': 'current',
         }
-    
+
     def _copy_bom(self):
         active_draft = self.env['mrp.config.settings']._get_parameter(
             'active.draft')
@@ -129,11 +129,13 @@ class MrpBom(models.Model):
             'active': active_draft and active_draft.value or False,
             'parent_bom': self.id,
         })
-        for bom_line in self.bom_line_ids:
-            if bom_line.product_id.product_tmpl_id.bom_ids and bom_line.product_id.product_tmpl_id.bom_count > 0:
-                for bom in bom_line.product_id.product_tmpl_id.bom_ids:
-                    if bom.version == self.version:
-                        bom.button_new_version()
+        if self.type == 'normal':
+            for bom_line in self.bom_line_ids:
+                if (bom_line.product_id.product_tmpl_id.bom_ids
+                        and bom_line.product_id.product_tmpl_id.bom_count > 0):
+                    for bom in bom_line.product_id.product_tmpl_id.bom_ids:
+                        if bom.version == self.version:
+                            bom.button_new_version()
         return new_bom
 
     @api.multi
@@ -178,7 +180,7 @@ class MrpBom(models.Model):
             product_tmpl_id=product_tmpl_id, product_id=product_id,
             properties=properties)
         return bom_id
-    
+
     @api.multi
     def name_get(self):
         res = []


### PR DESCRIPTION
Le programme atteint la limite de récursion dans le fichier coopiteasy/addons/mrp_bom_version/models/mrp_bom.py:

- `button_new_version` appelle `_copy_bom` qui rappelle `button_new_version`

```python
@api.multi
def button_new_version(self):
    self.ensure_one()
    new_bom = self._copy_bom()
    ...

def _copy_bom(self):
    ...
    new_bom = self.copy({...
    for bom_line in self.bom_line_ids:
        if bom_line.product_id.product_tmpl_id.bom_ids and bom_line.product_id.product_tmpl_id.bom_count > 0:
            for bom in bom_line.product_id.product_tmpl_id.bom_ids:
                if bom.version == self.version:
                    bom.button_new_version()
    return new_bom
```
Si je comprends bien, quand tu crées un nouveau BOM, odoo copie le bom courant et créé un nouveau bom pour tous les bom liés à des produits du bom courant. Comme ici, on est dans un casier mixte, on se retrouve à regénérer des boms pour tous les autres casiers, bouteilles, bières vertes, ... et on arrive à la récursion maximale (grosse combinatoire). Je n'ai pas identifié si, en plus, on arrive à une boucle infinie.

Je répare en ne regénérant de bom que si le produit manufacturé est le même.
