### PR TITLE
[IMP] resource_activity: access to sale orders

### DIFF
--- a/resource_activity/security/ir.model.access.csv
+++ b/resource_activity/security/ir.model.access.csv
@@ -23,4 +23,5 @@ access_res_company_note_manager,res.company.note,model_res_company_note,resource
 access_res_company_note_user,res.company.note,model_res_company_note,resource_planning.group_resource_user,1,1,1,0
 access_resource_location_terms_manager,resource.location.terms,model_resource_location_terms,resource_planning.group_resource_manager,1,1,1,1
 access_resource_location_terms_user,resource.location.terms,model_resource_location_terms,resource_planning.group_resource_user,1,1,1,0
-
+access_sale_order_user,access_sale_order_user,sale.model_sale_order,resource_planning.group_resource_user,1,1,1,0
+access_sale_order_user,access_sale_order_user,sale.model_sale_order,resource_planning.group_resource_manager,1,1,1,0


### PR DESCRIPTION
Avant:

- les users de resource_planning devaient aussi avoir le droit comptabilité/facturer pour voir les sale order liés aux activités d'autres utilisateurs

Après

- Ajouter le droit correspondant dans ressource_activity

Question à @houssine78 : 

Tu vois d'autres raisons pour laquelle on a mis le droit de facturation aux utilisateurs de resource_planning chez Pro Vélo?