### PR TITLE
Modifying the font-awesome icon used for activity to a bicycle instead of a dollar sign

### DIFF
--- a/resource_activity/views/partner_views.xml
+++ b/resource_activity/views/partner_views.xml
@@ -30,7 +30,7 @@
                     <button class="oe_stat_button" type="action"
                             name="%(resource_activity.act_res_partner_2_resource_activity)d"
                             attrs="{'invisible': [('customer', '=', False)]}"
-                            icon="fa-usd">
+                            icon="fa-bicycle">
                         <field string="Activities" name="activity_count" widget="statinfo"/>
                     </button>
                 </div>


### PR DESCRIPTION
Hey @robinkeunen,

I just did a tiny modification: I set the icon for the activity button in partners views to use the bicycle icon instead of the dollar sign.
That's more in line with who we are ;-)

I just modified the font-awesome identifier, so there is no external dependency.

Could you please merge it (and put it in production) if and when you have time (emergcy = lowest possible).

Thank you,

Jérémie