### PR TITLE
[IMP] pv_custom: journal code length <= 4

### DIFF
--- a/provelo_customization/__openerp__.py
+++ b/provelo_customization/__openerp__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Provelo Customization",
-    "version": "9.0.1.0",
+    "version": "9.0.1.1.0",
     "depends": [
         "csv_export_invoice",
         "csv_export_partner",
@@ -30,13 +30,22 @@
         "resource_activity",
         "web_readonly_bypass",
         "l10n_be_invoice_bba",
+        "account_archive_journals",
     ],
     "author": "Coop IT Easy SCRLfs",
     "license": "AGPL-3",
     "category": "",
     "website": "www.coopiteasy.be",
     "description": """
-        Specifics customizations for Pro Velo
+        * default value on invoice policy to order
+        * default value on res_partner out_inv_comm_type to bba
+        * default value on res_partner out_inv_comm_algorithm to random
+        * automatic validation of invoices
+        * add default values onavailable holidays report
+        * add security rules for hr holydays access
+        * location search  filters
+        * customize holiday, timesheet and res_partner views
+        * constraint on account journal code length
     """,
     "data": [
         "views/hr_holidays_view.xml",

--- a/provelo_customization/models/__init__.py
+++ b/provelo_customization/models/__init__.py
@@ -1,3 +1,4 @@
+from . import account_journal
 from . import product_template
 from . import res_partner
 from . import sale_order

--- a/provelo_customization/models/account_journal.py
+++ b/provelo_customization/models/account_journal.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, _, api
+from openerp.exceptions import ValidationError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    @api.multi
+    @api.constrains("code")
+    def _check_code_length(self):
+        for journal in self:
+            if journal.active and journal.code and len(journal.code) > 4:
+                raise ValidationError(_(
+                    "Journal code cannot be longer than 4 characters"
+                ))


### PR DESCRIPTION
En test: 

```sql
update account_journal set active = false where code = 'FACTU';
```

Déjà désactivé en prod.