### PR TITLE
[FIX] resource_activity: company_address div name

### DIFF
--- a/resource_activity/reports/layouts.xml
+++ b/resource_activity/reports/layouts.xml
@@ -31,7 +31,7 @@
 
     <template id="extend_external_layout_header" inherit_id="report.external_layout_header">
         <xpath expr="//div[@name='company_address']" position="replace">
-            <div class="col-xs-5">
+            <div class="col-xs-5" name="company_address">
                 <div t-if="location.address">
                     <div t-field="location.address"
                          t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=5520&view_type=form&model=project.task&action=475&active_id=27)

Other modules inherited from this view e.g. `<xpath expr="//div[@name='company_address']" ...>`, but a previous commit replaced this div with a div with a different name.