### PR TITLE
[ADD] resource_activity: weekday in activity tree view

### DIFF
--- a/resource_activity/models/resource_activity.py
+++ b/resource_activity/models/resource_activity.py
@@ -111,6 +111,12 @@ class ResourceActivity(models.Model):
             else:
                 activity.registrations_paid = False
 
+    @api.multi
+    @api.depends("date_start")
+    def _compute_dayofweek(self):
+        for activity in self:
+            activity.dayofweek = datetime.strftime(fields.Date.from_string(activity.date_start), '%A')
+
     @api.model
     def init_payments_fields(self):
         activities = self.search([])
@@ -143,6 +149,7 @@ class ResourceActivity(models.Model):
         string="Product Participation",
         domain=[("is_participation", "=", True)],
     )
+    dayofweek = fields.Char(string="Day", compute="_compute_dayofweek")
     date_start = fields.Datetime(string="Date start", required=True)
     date_end = fields.Datetime(string="Date end", required=True)
     duration = fields.Char(

--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -52,11 +52,12 @@
                 <tree>
                     <field name="is_start_outside_opening_hours" invisible="True"/>
                     <field name="is_end_outside_opening_hours" invisible="True"/>
+                    <field name="dayofweek"/>
+                    <field name="date_start" fg_color="red:is_start_outside_opening_hours==True;"/>
+                    <field name="date_end" fg_color="red:is_end_outside_opening_hours==True;"/>
                     <field name="description"/>
                     <field name="partner_id"/>
                     <field name="activity_type"/>
-                    <field name="date_start" fg_color="red:is_start_outside_opening_hours==True;"/>
-                    <field name="date_end" fg_color="red:is_end_outside_opening_hours==True;"/>
                     <field name="location_id"/>
                     <field name="state"/>
                     <field name="registrations_expected" string="Registrations"/>


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web?token=R0Qs92cjQIn6BsLb5XTZ&db=coopiteasy#id=3483&view_type=form&model=project.task&menu_id=338&action=479)

This PR adds a new field containing the weekday to the resource activity tree view, and moves the date column to the left.