### PR TITLE
[ADD] resource_activity: add internal comment to D-day report

### DIFF
--- a/resource_activity/models/resource_activity.py
+++ b/resource_activity/models/resource_activity.py
@@ -181,7 +181,8 @@ class ResourceActivity(models.Model):
     departure = fields.Char(string="Departure")
     arrival = fields.Char(string="Arrival")
     description = fields.Char(string="Description")
-    comment = fields.Html(string="Comment")
+    comment = fields.Html(string="Guide Comment")
+    internal_comment = fields.Html(string="Internal Comment")
     activity_type = fields.Many2one(
         "resource.activity.type", string="Activity type", required=True
     )

--- a/resource_activity/reports/activity_registration_report.xml
+++ b/resource_activity/reports/activity_registration_report.xml
@@ -160,8 +160,12 @@
                 </div>
                 <div class="row" name="row5" style="margin-top:5px">
                     <div class="col-xs-12" name="comments" style="border: medium dashed #00B9E4;">
-                        <h2 style="margin-top:5px">Comments</h2>
+                        <h2 style="margin-top:5px">Guide Comments</h2>
                         <p t-field="o.comment" name="comments-field" style="font-size: 16px;"/>
+                    </div>
+                    <div class="col-xs-12" name="internal_comments" style="border: medium dashed #00B9E4;">
+                        <h2 style="margin-top:5px">Internal Comments</h2>
+                        <p t-field="o.internal_comment" name="internal-comments-field" style="font-size: 16px;"/>
                     </div>
                 </div>
 

--- a/resource_activity/reports/activity_report.xml
+++ b/resource_activity/reports/activity_report.xml
@@ -133,7 +133,7 @@
                 </div>
                 <div class="row" name="row5" style="margin-top:5px">
                     <div class="col-xs-12" name="comments" style="border: medium dashed #00B9E4;">
-                        <h2 style="margin-top:5px">Comments</h2>
+                        <h2 style="margin-top:5px">Guide Comments</h2>
                         <p t-field="o.comment" name="comments-field" style="font-size: 16px;"/>
                     </div>
                 </div>

--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -166,7 +166,12 @@
                                 <field name="departure"/>
                                 <field name="arrival"/>
                                 <field name="langs" options="{'no_create': True}" widget='many2many_tags'/>
+                            </group>
+                            <group>
                                 <field name="comment"/>
+                            </group>
+                            <group>
+                                <field name="internal_comment"/>
                             </group>
                         </group>
                         <notebook>


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web?token=R0Qs92cjQIn6BsLb5XTZ&db=coopiteasy#id=1330&view_type=form&model=project.task&menu_id=338&action=479)

This PR adds internal comment to D-day report

I reordered the comment fields in the view because they took up too much space when displayed as consecutive HTML fields.