### PR TITLE
[ADD] resource_activity: location_ids on activity type

### DIFF
--- a/resource_activity/models/resource_activity.py
+++ b/resource_activity/models/resource_activity.py
@@ -30,6 +30,7 @@ class ResourceActivityType(models.Model):
         groups="analytic.group_analytic_accounting",
     )
     product_ids = fields.Many2many("product.product", string="Product")
+    location_ids = fields.Many2many("resource.location",string="Locations")
     active = fields.Boolean("Active", default=True)
 
 

--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -160,7 +160,7 @@
                                 <field name="booking_type"/>
                                 <field name="date_lock"
                                        attrs="{'invisible':[('booking_type','!=','option')],'required':[('booking_type','=','option')]}"/>
-                                <field name="activity_type" widget="selection"/>
+                                <field name="activity_type" widget="selection" domain="[('location_ids','in', location_id)]" />
                                 <field name="activity_theme" widget="selection"/>
                                 <field name="analytic_account"/>
                                 <field name="departure"/>
@@ -448,6 +448,7 @@
                         <group>
                             <group>
                                 <field name="name"/>
+                                <field name="location_ids" widget="many2many_tags"/>
                             </group>
                             <group>
                                 <!-- not used -->


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web?token=R0Qs92cjQIn6BsLb5XTZ&db=coopiteasy#id=3900&view_type=form&model=project.task&menu_id=338&action=479)

This PR add locations to activity types, and when creating an activity only shows activity types of the activity's location.