### PR TITLE
[FIX] r_activity: guide only activities create sale orders

### DIFF
--- a/resource_activity/demo/demo.xml
+++ b/resource_activity/demo/demo.xml
@@ -13,4 +13,18 @@
     <record id="base.user_demo" model="res.users">
         <field name="resource_location" ref="resource_planning.main_location"/>
     </record>
+
+    <record id="guide_product_product_demo" model="product.product">
+        <field name="name">Guide Product</field>
+        <field name="list_price">100</field>
+    </record>
+
+    <record id="res_partner_friendly_guide_demo" model="res.partner">
+        <field name="name">Friendly Guide</field>
+        <field name="is_guide" eval="True"/>
+    </record>
+    <record id="res_partner_mean_guide_demo" model="res.partner">
+        <field name="name">Mean Guide</field>
+        <field name="is_guide" eval="True"/>
+    </record>
 </odoo>

--- a/resource_activity/models/resource_activity.py
+++ b/resource_activity/models/resource_activity.py
@@ -649,6 +649,17 @@ class ResourceActivity(models.Model):
                     )
                 )
 
+        if activity.need_guide and activity.partner_id:
+            prepared_lines.append(
+                OrderLine(
+                    activity.partner_id.id,
+                    activity.guide_product_id,
+                    len(activity.guides),
+                    "guide",
+                    None,
+                )
+            )
+
         return prepared_lines
 
     def _create_sale_order(self, activity, partner_id):
@@ -683,6 +694,7 @@ class ResourceActivity(models.Model):
             lambda record: record.state != "cancelled"
         )
 
+        # could probably be a whole lot simpler
         sale_orders = {}
         for registration in registrations:
             if activity.partner_id:
@@ -701,6 +713,12 @@ class ResourceActivity(models.Model):
                 else:
                     order_id = self._create_sale_order(activity, partner)
                     sale_orders[partner] = order_id
+
+        # cringe, refactor when unit tested
+        if not registrations and activity.partner_id:
+            partner = activity.partner_id.id
+            order_id = self._create_sale_order(activity, partner)
+            sale_orders[partner] = order_id
 
         return sale_orders
 
@@ -740,22 +758,18 @@ class ResourceActivity(models.Model):
                         self.create_order_line(
                             order_id, product, qty, resource_delivery=True,
                         )
+                    elif type == "guide":
+                        self.create_order_line(
+                            order_id, product, qty, resource_guide=True
+                        )
                     else:
                         self.create_order_line(
                             order_id, product, qty, participation_line=True,
                         )
 
                 for pl in partner_lines:
-                    pl.registration.write({"sale_order_id": order_id.id})
-
-            if activity.need_guide and activity.partner_id:
-                order = sale_orders.values().pop()
-                self.create_order_line(
-                    order,
-                    activity.guide_product_id,
-                    len(activity.guides),
-                    resource_guide=True,
-                )
+                    if pl.registration:
+                        pl.registration.write({"sale_order_id": order_id.id})
 
     @api.multi
     def action_quotation(self):

--- a/resource_activity/tests/test_resource_activity.py
+++ b/resource_activity/tests/test_resource_activity.py
@@ -9,9 +9,19 @@ from openerp.tests import common
 class TestResourceActivity(common.TransactionCase):
     def setUp(self):
         super(TestResourceActivity, self).setUp()
+        self.partner_demo = self.env.ref("base.partner_demo")
+        self.guide_partner_1 = self.browse_ref(
+            "resource_activity.res_partner_friendly_guide_demo"
+        )
+        self.guide_partner_2 = self.browse_ref(
+            "resource_activity.res_partner_mean_guide_demo"
+        )
         self.main_location = self.browse_ref("resource_planning.main_location")
         self.activity_type = self.browse_ref(
             "resource_activity.resource_activity_type_tour_demo"
+        )
+        self.guide_product = self.browse_ref(
+            "resource_activity.guide_product_product_demo"
         )
 
     def test_compute_available_resources(self):
@@ -67,3 +77,82 @@ class TestResourceActivity(common.TransactionCase):
             for av_categ in activity.available_category_ids
         }
         self.assertEquals({1: 2, 2: 1}, categories)
+
+    def test_create_guide_only_sale_order_no_guides(self):
+        activity_obj = self.env["resource.activity"]
+
+        activity = activity_obj.create(
+            {
+                "partner_id": self.partner_demo.id,
+                "date_start": "2020-11-24 19:30",
+                "date_end": "2020-11-24 20:00",
+                "location_id": self.main_location.id,
+                "activity_type": self.activity_type.id,
+                "need_guide": True,
+                "guide_product_id": self.guide_product.id,
+            }
+        )
+        activity.create_sale_order()
+        sale_order = activity.sale_orders
+        self.assertEquals(len(sale_order.order_line), 1)
+        self.assertEquals(activity.sale_orders.amount_total, 0)
+
+    def test_create_guide_only_sale_order_with_guides(self):
+        activity_obj = self.env["resource.activity"]
+
+        activity = activity_obj.create(
+            {
+                "partner_id": self.partner_demo.id,
+                "date_start": "2020-11-24 19:30",
+                "date_end": "2020-11-24 20:00",
+                "location_id": self.main_location.id,
+                "activity_type": self.activity_type.id,
+                "need_guide": True,
+                "guide_product_id": self.guide_product.id,
+                "guides": [
+                    (4, self.guide_partner_1.id, 0),
+                    (4, self.guide_partner_2.id, 0),
+                ],
+            }
+        )
+        activity.create_sale_order()
+        sale_order = activity.sale_orders
+        self.assertEquals(len(sale_order.order_line), 1)
+        self.assertEquals(activity.sale_orders.amount_total, 230)
+
+    def test_create_guide_only_sale_order_with_guides_and_registrations(self):
+        activity_obj = self.env["resource.activity"]
+
+        activity = activity_obj.create(
+            {
+                "partner_id": self.partner_demo.id,
+                "date_start": "2020-11-24 19:30",
+                "date_end": "2020-11-24 20:00",
+                "location_id": self.main_location.id,
+                "activity_type": self.activity_type.id,
+                "need_guide": True,
+                "guide_product_id": self.guide_product.id,
+                "guides": [
+                    (4, self.guide_partner_1.id, 0),
+                    (4, self.guide_partner_2.id, 0),
+                ],
+                "registrations": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attendee_id": self.partner_demo.id,
+                            "quantity": 2,
+                            "quantity_needed": 0,
+                            "booking_type": "booked",
+                            "state": "booked",
+                            "bring_bike": True,
+                        },
+                    )
+                ],
+            }
+        )
+        activity.create_sale_order()
+        sale_order = activity.sale_orders
+        self.assertEquals(len(sale_order.order_line), 1)
+        self.assertEquals(activity.sale_orders.amount_total, 230)


### PR DESCRIPTION
[T0469 - O25 - Passer une activité en bon de commande qd il n'y a qu'un guide](https://gestion.coopiteasy.be/web#id=1881&view_type=form&model=project.task&action=475&active_id=27)

- add demo and tests to reproduce
- create sale order when no registration exists
- create guide order line like registration lines