### PR TITLE
[FIX] product_label_report: check barcode field before printing it ba…

### DIFF
--- a/product_label_report/report/layout.xml
+++ b/product_label_report/report/layout.xml
@@ -2,11 +2,12 @@
 <odoo>
 
     <template id="product_label_content_barcode_and_name">
-        <img alt="Barcode" t-if="len(product.barcode) == 13" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(product.barcode or ''), 600, 150)" class="barcode-img"/>
-        <img alt="Barcode" t-elif="len(product.barcode) == 8" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(product.barcode or ''), 600, 150)" class="barcode-img"/>
-        <img alt="Barcode" t-else="" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(product.barcode or ''), 600, 150)" class="barcode-img"/>
-
-        <span t-field="product.barcode" class="barcode"/>
+        <t t-if="product.barcode">
+            <img alt="Barcode" t-if="len(product.barcode) == 13" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(product.barcode or ''), 600, 150)" class="barcode-img"/>
+            <img alt="Barcode" t-elif="len(product.barcode) == 8" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(product.barcode or ''), 600, 150)" class="barcode-img"/>
+            <img alt="Barcode" t-else="" t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(product.barcode or ''), 600, 150)" class="barcode-img"/>
+            <span t-field="product.barcode" class="barcode"/>
+        </t>
         <div class="product-name" t-esc="product.name"/>
     </template>
 


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web?token=R0Qs92cjQIn6BsLb5XTZ&db=coopiteasy#id=5437&view_type=form&model=project.task&action=479)

Check barcode field before printing it based on it's length. Otherwise the evaluation `t-if="len(product.barcode) == 13"` errors on `len(False)`.

Inspired by [this](https://github.com/coopiteasy/OCB/blob/ee6b2074f09a6e47b0c6bf65873e45b0a68330b3/addons/product/report/product_product_templates.xml#L55) line in the `product` module.