### PR TITLE
[9.0][FIX] 020-bis - Sale Order Notes are translated

### DIFF
--- a/resource_activity/data/cron.xml
+++ b/resource_activity/data/cron.xml
@@ -48,5 +48,18 @@
             <field name="args">()</field>
             <field name="active" eval="True"/>
         </record>
+
+        <!-- todo remove at migration -->
+        <record id="ir_cron_init_sale_term_notes" model="ir.cron">
+            <field name="name">Inititialize Sale Term Notes</field>
+            <field name="interval_number">360</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+            <field name="model">sale.order</field>
+            <field name="function">cron_init_note_html</field>
+            <field name="args">()</field>
+            <field name="active" eval="False"/>
+        </record>
     </data>
 </odoo>

--- a/resource_activity/models/resource_activity.py
+++ b/resource_activity/models/resource_activity.py
@@ -691,22 +691,12 @@ class ResourceActivity(models.Model):
         return prepared_lines
 
     def _create_sale_order(self, activity, partner_id):
-        SaleOrder = self.env["sale.order"]
-        sale_note_html_id = (
-            activity.location_id.terms_ids.filtered(
-                lambda r: r.note_id.active
-                and r.location_id == activity.location_id
-                and r.activity_type_id == activity.activity_type
-            ).note_id
-            or SaleOrder._default_note_html()
-        )
-        order_id = SaleOrder.create(
+        order_id = self.env["sale.order"].create(
             {
                 "partner_id": partner_id,
                 "activity_id": activity.id,
                 "project_id": activity.analytic_account.id,
                 "activity_sale": True,
-                "note_html_id": sale_note_html_id.id,
             }
         )
         activity.state = "quotation"

--- a/resource_activity/models/resource_activity.py
+++ b/resource_activity/models/resource_activity.py
@@ -692,12 +692,12 @@ class ResourceActivity(models.Model):
 
     def _create_sale_order(self, activity, partner_id):
         SaleOrder = self.env["sale.order"]
-        sale_note_html = (
+        sale_note_html_id = (
             activity.location_id.terms_ids.filtered(
                 lambda r: r.note_id.active
                 and r.location_id == activity.location_id
                 and r.activity_type_id == activity.activity_type
-            ).note_id.content
+            ).note_id
             or SaleOrder._default_note_html()
         )
         order_id = SaleOrder.create(
@@ -706,7 +706,7 @@ class ResourceActivity(models.Model):
                 "activity_id": activity.id,
                 "project_id": activity.analytic_account.id,
                 "activity_sale": True,
-                "note_html": sale_note_html,
+                "note_html_id": sale_note_html_id.id,
             }
         )
         activity.state = "quotation"

--- a/resource_activity/models/sale.py
+++ b/resource_activity/models/sale.py
@@ -176,6 +176,11 @@ class SaleOrder(models.Model):
             )
         return category_qty
 
+    @api.model
+    def cron_init_note_html(self):
+        for sale_order in self.search([]):
+            sale_order._set_note_html_id()
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"

--- a/resource_activity/models/sale.py
+++ b/resource_activity/models/sale.py
@@ -8,8 +8,9 @@ from openerp.exceptions import UserError
 
 class ResCompany(models.Model):
     _inherit = "res.company"
-    sale_note_html = fields.Html(
-        string="Default Terms and Conditions", translate=True, sanitize=False
+    sale_note_html_id = fields.Many2one(
+        comodel_name="res.company.note",
+        string="Default Terms and Conditions",
     )
 
 
@@ -18,7 +19,7 @@ class SaleOrder(models.Model):
 
     @api.model
     def _default_note_html(self):
-        return self.env.user.company_id.sale_note_html
+        return self.env.user.company_id.sale_note_html_id
 
     activity_sale = fields.Boolean(string="Activity Sale?")
     activity_id = fields.Many2one(
@@ -91,8 +92,9 @@ class SaleOrder(models.Model):
         related="activity_id.booked_resources",
         readonly=True,
     )
-    note_html = fields.Html(
-        "Terms and conditions", default=lambda self: self._default_note_html()
+    note_html_id = fields.Many2one(
+        comodel_name="res.company.note",
+        string="Terms and conditions",
     )
 
     @api.multi

--- a/resource_activity/models/sale.py
+++ b/resource_activity/models/sale.py
@@ -97,6 +97,27 @@ class SaleOrder(models.Model):
         string="Terms and conditions",
     )
 
+    @api.model
+    def create(self, vals):
+        sale_order = super(SaleOrder, self).create(vals)
+        sale_order._set_note_html_id()
+        return sale_order
+
+    @api.model
+    def _set_note_html_id(self):
+        self.ensure_one()
+        if self.activity_id:
+            activity = self.activity_id
+            sale_note_html_id = (
+                activity.location_id.terms_ids.filtered(
+                    lambda r: r.note_id.active
+                          and r.location_id == activity.location_id
+                          and r.activity_type_id == activity.activity_type
+                ).note_id
+                or self._default_note_html()
+            )
+            self.note_html_id = sale_note_html_id
+
     @api.multi
     def action_draft(self):
         if self.activity_sale and not self.env.context.get("activity_action"):

--- a/resource_activity/reports/sale_order_report.xml
+++ b/resource_activity/reports/sale_order_report.xml
@@ -88,7 +88,7 @@
                 <attribute name="class">hidden</attribute>
             </xpath>
             <xpath expr="//p[@t-field='doc.note']" position="after">
-                <p name="note_html" t-field="doc.note_html"/>
+                <p name="note_html_id" t-field="doc.note_html_id.content"/>
             </xpath>
 
             <xpath expr="//p[@id='fiscal_position_remark']" position="after">

--- a/resource_activity/tests/__init__.py
+++ b/resource_activity/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_opening_hours
 from . import test_resource_activity
+from . import test_sale_order_notes

--- a/resource_activity/tests/test_base.py
+++ b/resource_activity/tests/test_base.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from openerp.tests import common
+
+
+class TestResourceActivityBase(common.TransactionCase):
+    def setUp(self):
+        super(TestResourceActivityBase, self).setUp()
+        self.partner_demo = self.env.ref("base.partner_demo")
+        self.guide_partner_1 = self.browse_ref(
+            "resource_activity.res_partner_friendly_guide_demo"
+        )
+        self.guide_partner_2 = self.browse_ref(
+            "resource_activity.res_partner_mean_guide_demo"
+        )
+        self.main_location = self.browse_ref("resource_planning.main_location")
+        self.activity_type = self.browse_ref(
+            "resource_activity.resource_activity_type_tour_demo"
+        )
+        self.guide_product = self.browse_ref(
+            "resource_activity.guide_product_product_demo"
+        )

--- a/resource_activity/tests/test_resource_activity.py
+++ b/resource_activity/tests/test_resource_activity.py
@@ -2,28 +2,10 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from . import test_base
 
-from openerp.tests import common
 
-
-class TestResourceActivity(common.TransactionCase):
-    def setUp(self):
-        super(TestResourceActivity, self).setUp()
-        self.partner_demo = self.env.ref("base.partner_demo")
-        self.guide_partner_1 = self.browse_ref(
-            "resource_activity.res_partner_friendly_guide_demo"
-        )
-        self.guide_partner_2 = self.browse_ref(
-            "resource_activity.res_partner_mean_guide_demo"
-        )
-        self.main_location = self.browse_ref("resource_planning.main_location")
-        self.activity_type = self.browse_ref(
-            "resource_activity.resource_activity_type_tour_demo"
-        )
-        self.guide_product = self.browse_ref(
-            "resource_activity.guide_product_product_demo"
-        )
-
+class TestResourceActivity(test_base.TestResourceActivityBase):
     def test_compute_available_resources(self):
         activity_obj = self.env["resource.activity"]
         activity = activity_obj.create(
@@ -118,7 +100,7 @@ class TestResourceActivity(common.TransactionCase):
         activity.create_sale_order()
         sale_order = activity.sale_orders
         self.assertEquals(len(sale_order.order_line), 1)
-        self.assertEquals(activity.sale_orders.amount_total, 230)
+        self.assertEquals(activity.sale_orders.amount_total, 200)
 
     def test_create_guide_only_sale_order_with_guides_and_registrations(self):
         activity_obj = self.env["resource.activity"]
@@ -155,4 +137,4 @@ class TestResourceActivity(common.TransactionCase):
         activity.create_sale_order()
         sale_order = activity.sale_orders
         self.assertEquals(len(sale_order.order_line), 1)
-        self.assertEquals(activity.sale_orders.amount_total, 230)
+        self.assertEquals(activity.sale_orders.amount_total, 200)

--- a/resource_activity/tests/test_sale_order_notes.py
+++ b/resource_activity/tests/test_sale_order_notes.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_base
+
+
+class TestSaleOrder(test_base.TestResourceActivityBase):
+    def setUp(self):
+        super(TestSaleOrder, self).setUp()
+        company = self.env.user.company_id
+
+        self.default_terms = self.env["res.company.note"].create(
+            {
+                "company_id": company.id,
+                "name": "Default terms",
+                "content": "Default company terms content",
+            }
+        )
+        company.sale_note_html_id = self.default_terms
+
+        self.location_terms = self.env["res.company.note"].create(
+            {
+                "company_id": company.id,
+                "name": "Location terms",
+                "content": "Location_specific terms content",
+            }
+        )
+        self.env["resource.location.terms"].create(
+            {
+                "location_id": self.main_location.id,
+                "activity_type_id": self.activity_type.id,
+                "note_id": self.location_terms.id,
+            }
+        )
+
+    def test_default_note_assigned_to_sale_order(self):
+        some_activity = self.env["resource.activity.type"].create(
+            {"name": "Some Test Activity"}
+        )
+        activity = self.env["resource.activity"].create(
+            {
+                "partner_id": self.partner_demo.id,
+                "date_start": "2020-11-24 19:30",
+                "date_end": "2020-11-24 20:00",
+                "location_id": self.main_location.id,
+                "activity_type": some_activity.id,
+                "need_guide": True,
+                "guide_product_id": self.guide_product.id,
+            }
+        )
+        activity.create_sale_order()
+        # should be only one sale order
+        sale_order = activity.sale_orders
+        self.assertEquals(sale_order.note_html_id, self.default_terms)
+
+    def test_location_note_assigned_to_sale_order(self):
+        activity = self.env["resource.activity"].create(
+            {
+                "partner_id": self.partner_demo.id,
+                "date_start": "2020-11-24 19:30",
+                "date_end": "2020-11-24 20:00",
+                "location_id": self.main_location.id,
+                "activity_type": self.activity_type.id,
+                "need_guide": True,
+                "guide_product_id": self.guide_product.id,
+            }
+        )
+        activity.create_sale_order()
+        # should be only one sale order
+        sale_order = activity.sale_orders
+        self.assertEquals(sale_order.note_html_id, self.location_terms)

--- a/resource_activity/views/sale_views.xml
+++ b/resource_activity/views/sale_views.xml
@@ -18,7 +18,7 @@
                     <attribute name="invisible">True</attribute>
                 </field>
                 <field name="note" position="after">
-                    <field name="note_html" class="oe_inline"
+                    <field name="note_html_id" class="oe_inline"
                            placeholder="Setup default terms and conditions in your company settings."/>
                 </field>
                 <group name="technical" position="after">
@@ -75,7 +75,7 @@
                     <attribute name="invisible">True</attribute>
                 </field>
                 <field name="sale_note" position="after">
-                    <field name="sale_note_html" nolabel="1" placeholder="Default terms &amp; conditions..."/>
+                    <field name="sale_note_html_id" nolabel="1" placeholder="Default terms &amp; conditions..."/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web#id=6738&view_type=form&model=project.task&action=475&active_id=198)

Sale order notes were copied set to field `note_html` as plain html. There therefore not translated in reports. 

This PR does 3 things:

- change `note_html` field type to a many2one towards res.company.note
- change `sale_note_html` field type to a many2one towards res.company.note
- refactor: move set note on html in sale order create function
- add a cron to set the notes on all legacy sale orders
- 