### PR TITLE
[12.0][ADD] sale_order_volume: pallet count

### DIFF
--- a/sale_order_volume/README.rst
+++ b/sale_order_volume/README.rst
@@ -19,16 +19,27 @@ Sale Order Volume
 
 |badge1| |badge2| |badge3| 
 
-Computes the volume of products per category ordered and display it on
+Computes the volume of products (and its corresponding number of pallets) per category ordered and display it on
 
 - sale order page,
 - sale order report,
 - website shop cart website page.
 
+Pallet volume is configurable.
+
 **Table of contents**
 
 .. contents::
    :local:
+
+Configuration
+=============
+
+Pallet Volume
+~~~~~~~~~~~~~
+
+On Settings > General Settings > Sale (or Sales > Configuration > Settings),
+set a default pallet volume in "Volumes" section.
 
 Bug Tracker
 ===========
@@ -46,13 +57,14 @@ Credits
 Authors
 ~~~~~~~
 
-* Robin Keunen <robin@coopiteasy.be>
 * Coop IT Easy SCRLfs
 
 Contributors
 ~~~~~~~~~~~~
 
 * Robin Keunen <robin@coopiteasy.be>
+* Elouan Le Bars <elouan@coopiteasy.be>
+* Vincent Van Rossem <vincent@coopiteasy.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_order_volume/__manifest__.py
+++ b/sale_order_volume/__manifest__.py
@@ -18,9 +18,9 @@
 ##############################################################################
 {
     "name": "Sale Order Volume",
-    "version": "12.0.1.0.0",
-    "depends": ["sale", "website_sale"],
-    "author": "Robin Keunen <robin@coopiteasy.be>, Coop IT Easy SCRLfs",
+    "version": "12.0.1.1.0",
+    "depends": ["sale", "stock", "website_sale"],
+    "author": "Coop IT Easy SCRLfs",
     "license": "AGPL-3",
     "category": "Sale",
     "website": "https://www.coopiteasy.be",
@@ -29,9 +29,11 @@
     category ordered and display it on
     """,
     "data": [
+        "data/pallet_volume_data.xml",
         "views/sale_order.xml",
         "views/shopping_cart.xml",
         "reports/report_saleorder.xml",
+        "views/res_config_settings_views.xml",
         "security/ir.model.access.csv",
     ],
     "demo": ["demo/demo.xml"],

--- a/sale_order_volume/data/pallet_volume_data.xml
+++ b/sale_order_volume/data/pallet_volume_data.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="sale_order_volume.pallet_volume" model="ir.config_parameter">
+        <field name="key">sale_order_volume.pallet_volume</field>
+        <field name="value" type="float">1.75</field>
+    </record>
+</odoo>

--- a/sale_order_volume/models/__init__.py
+++ b/sale_order_volume/models/__init__.py
@@ -1,1 +1,2 @@
+from . import res_config_settings
 from . import sale_order

--- a/sale_order_volume/models/res_config_settings.py
+++ b/sale_order_volume/models/res_config_settings.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    pallet_volume = fields.Float(
+        string="Pallet Volume (m³)",
+        help="Pallet Volume in cubic meter",
+        config_parameter="sale_order_volume.pallet_volume",
+        digits=(3, 2),
+    )

--- a/sale_order_volume/readme/CONFIGURE.rst
+++ b/sale_order_volume/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+Pallet Volume
+~~~~~~~~~~~~~
+
+On Settings > General Settings > Sale (or Sales > Configuration > Settings),
+set a default pallet volume in "Volumes" section.

--- a/sale_order_volume/readme/CONTRIBUTORS.rst
+++ b/sale_order_volume/readme/CONTRIBUTORS.rst
@@ -1,1 +1,3 @@
 * Robin Keunen <robin@coopiteasy.be>
+* Elouan Le Bars <elouan@coopiteasy.be>
+* Vincent Van Rossem <vincent@coopiteasy.be>

--- a/sale_order_volume/readme/DESCRIPTION.rst
+++ b/sale_order_volume/readme/DESCRIPTION.rst
@@ -1,5 +1,7 @@
-Computes the volume of products per category ordered and display it on
+Computes the volume of products (and its corresponding number of pallets) per category ordered and display it on
 
 - sale order page,
 - sale order report,
 - website shop cart website page.
+
+Pallet volume is configurable.

--- a/sale_order_volume/reports/report_saleorder.xml
+++ b/sale_order_volume/reports/report_saleorder.xml
@@ -10,6 +10,7 @@
                     <tr>
                         <th>Category</th>
                         <th class="text-right">Volume (m³)</th>
+                        <th class="text-right"># Pallets</th>
                     </tr>
                 </thead>
                 <tbody class="sale_tbody">
@@ -20,6 +21,9 @@
                             </td>
                             <td class="text-right">
                                 <span t-field="line.volume" />
+                            </td>
+                            <td class="text-right">
+                                <span t-field="line.pallet_count" />
                             </td>
                         </tr>
                     </t>

--- a/sale_order_volume/static/description/index.html
+++ b/sale_order_volume/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
 <title>Sale Order Volume</title>
 <style type="text/css">
 
@@ -368,26 +368,39 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/coopiteasy/addons/tree/12.0/sale_order_volume"><img alt="coopiteasy/addons" src="https://img.shields.io/badge/github-coopiteasy%2Faddons-lightgray.png?logo=github" /></a></p>
-<p>Computes the volume of products per category ordered and display it on</p>
+<p>Computes the volume of products (and its corresponding number of pallets) per category ordered and display it on</p>
 <ul class="simple">
 <li>sale order page,</li>
 <li>sale order report,</li>
 <li>website shop cart website page.</li>
 </ul>
+<p>Pallet volume is configurable.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id1">Configuration</a><ul>
+<li><a class="reference internal" href="#pallet-volume" id="id2">Pallet Volume</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id1">Configuration</a></h1>
+<div class="section" id="pallet-volume">
+<h2><a class="toc-backref" href="#id2">Pallet Volume</a></h2>
+<p>On Settings &gt; General Settings &gt; Sale (or Sales &gt; Configuration &gt; Settings),
+set a default pallet volume in “Volumes” section.</p>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/coopiteasy/addons/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -395,22 +408,23 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
-<li>Robin Keunen &lt;<a class="reference external" href="mailto:robin&#64;coopiteasy.be">robin&#64;coopiteasy.be</a>&gt;</li>
 <li>Coop IT Easy SCRLfs</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li>Robin Keunen &lt;<a class="reference external" href="mailto:robin&#64;coopiteasy.be">robin&#64;coopiteasy.be</a>&gt;</li>
+<li>Elouan Le Bars &lt;<a class="reference external" href="mailto:elouan&#64;coopiteasy.be">elouan&#64;coopiteasy.be</a>&gt;</li>
+<li>Vincent Van Rossem &lt;<a class="reference external" href="mailto:vincent&#64;coopiteasy.be">vincent&#64;coopiteasy.be</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/coopiteasy/addons/tree/12.0/sale_order_volume">coopiteasy/addons</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/sale_order_volume/tests/test_sale_order_volume.py
+++ b/sale_order_volume/tests/test_sale_order_volume.py
@@ -27,4 +27,7 @@ class SaleOrderVolumeCase(TransactionCase):
         )
 
         self.assertEquals(service_volume.volume, 0)
+        self.assertEquals(service_volume.pallet_count, 1)
         self.assertEquals(office_furniture_volume.volume, 15.6)
+        # (15.6 (volume) // 1.75 (pallet volume)) + 1 = 9
+        self.assertEquals(office_furniture_volume.pallet_count, 9)

--- a/sale_order_volume/views/res_config_settings_views.xml
+++ b/sale_order_volume/views/res_config_settings_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.sale.order.volume</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='sale_management']" position="inside">
+                <h2>Volumes</h2>
+                <div class="row mt16 o_settings_container" id="volume_settings">
+                    <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        id="pallet_volume_settings"
+                    >
+                        <div class="o_setting_right_pane">
+                            <label string="Pallet Volume" for="pallet_volume" />
+                            <div class="text-muted">
+                                Set a default pallet volume (m³)
+                            </div>
+                            <div class="mt8">
+                                <field name="pallet_volume" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_order_volume/views/sale_order.xml
+++ b/sale_order_volume/views/sale_order.xml
@@ -13,8 +13,14 @@
                 <page string="Volume of Products">
                     <group>
                         <field name="volume" />
+                        <field name="pallet_count" />
+                    </group>
+                    <group>
                         <field name="volume_per_category">
-                            <tree>
+                            <tree
+                                name="volume_per_category"
+                                string="Volume per Product Category"
+                            >
                                 <field name="category_id" />
                                 <field name="volume" />
                             </tree>

--- a/sale_order_volume/views/shopping_cart.xml
+++ b/sale_order_volume/views/shopping_cart.xml
@@ -1,33 +1,53 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+
+    <template id="volume_per_category">
+        <div
+            id="cart_volume_per_category"
+            t-att-class="extra_class or ''"
+            t-if="website_sale_order and website_sale_order.website_order_line"
+        >
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th class="col-md-2 col-3 noborder">Volume (m³)</th>
+                        <th class="col-md-2 col-3 noborder"># Pallets</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="text-xl-left noborder">
+                            <span
+                                t-field="website_sale_order.volume"
+                                style="white-space: nowrap;"
+                            />
+                        </td>
+
+                        <td class="text-xl-right noborder">
+                            <span
+                                t-field="website_sale_order.pallet_count"
+                                style="white-space: nowrap;"
+                            />
+                        </td>
+
+                    </tr>
+                </tbody>
+            </table>
+            <p id="pallet_footnote"><i>1 pallet = <t
+                        t-esc="website_sale_order.get_default_pallet_volume()"
+                    /> m³</i></p>
+        </div>
+    </template>
+
     <template id="short_cart_summary" inherit_id="website_sale.short_cart_summary">
         <div class="card-body" position="after">
             <div class="card-body">
-
-                <h4 class="d-none d-xl-block">Product Volumes (m³)</h4>
-
-                <div class="extra_class">
-                    <table class="table" name="volume-per-category">
-                        <tbody class="sale_tbody">
-                            <t
-                                t-set="category_volumes"
-                                t-value="website_sale_order.compute_order_product_category_volumes()"
-                            />
-                            <t t-foreach="category_volumes" t-as="line">
-                                <tr>
-                                    <td>
-                                        <span t-field="line.category_id" />
-                                    </td>
-                                    <td class="text-right">
-                                        <span t-field="line.volume" />
-                                    </td>
-                                </tr>
-                            </t>
-                        </tbody>
-                    </table>
+                <h4 class="d-none d-xl-block">Order Volume</h4>
+                <div>
+                    <t t-call="sale_order_volume.volume_per_category">
+                    </t>
                 </div>
             </div>
         </div>
-
     </template>
 </odoo>


### PR DESCRIPTION
##  [Task](https://gestion.coopiteasy.be/web#id=1744&view_type=form&model=project.task&action=479)

Inspired by #41 (9.0)

**Before :**
Computes the volume of products per category ordered and display it on
- sale order page,
- sale order report,
- website shop cart website page.

**After :**
The corresponding number of pallets is displayed on
- sale order page,
- website shop cart website page.

Pallet volume is configurable in General Settings > Sale

**Backend:**
"# Pallets" added on "Volume per Product Category"
![sale_order_volume-backend](https://user-images.githubusercontent.com/28013700/124793634-7cd97000-df4e-11eb-942a-cc8eec495d0b.png)


**Frontend:**
"Product Volumes'" summary adapted to add "# Pallets"
![sale_order_volume-website](https://user-images.githubusercontent.com/28013700/124793658-81058d80-df4e-11eb-8cf5-a8436f406691.png)
