### PR TITLE
[FIX] Freeze Python version to 3.9 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.9
   node: "14.13.0"
 repos:
   - repo: https://github.com/psf/black


### PR DESCRIPTION
pylint-odoo is incompatible with Python >3.9, see
<OCA/oca-addons-repo-template#80> and
<coopiteasy/cie-repository-template@04be2d4>.

(P.S., sorry for repeating this PR across repos :x)