### PR TITLE
12.0 legalsylvain account customer wallet

### DIFF
--- a/account_customer_wallet/__manifest__.py
+++ b/account_customer_wallet/__manifest__.py
@@ -17,6 +17,7 @@
     "excludes": [],
     "data": [
         "views/account_journal_views.xml",
+        "views/account_payment_views.xml",
         "views/res_config_settings_views.xml",
         "views/res_partner_views.xml",
     ],

--- a/account_customer_wallet/models/__init__.py
+++ b/account_customer_wallet/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_journal
+from . import account_payment
 from . import res_company
 from . import res_config_settings
 from . import res_partner

--- a/account_customer_wallet/models/account_payment.py
+++ b/account_customer_wallet/models/account_payment.py
@@ -1,0 +1,43 @@
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    is_customer_wallet_journal = fields.Boolean(
+        related="journal_id.is_customer_wallet_journal",
+    )
+
+    customer_wallet_balance = fields.Monetary(
+        string="Customer Wallet Balance",
+        currency_field="currency_id",
+        related="partner_id.customer_wallet_balance",
+    )
+
+    @api.multi
+    def post(self):
+        wallet_payments = self.filtered(
+            lambda x: x.journal_id.is_customer_wallet_journal
+        )
+
+        for payment in wallet_payments:
+            if payment.partner_id and payment.customer_wallet_balance < payment.amount:
+                raise UserError(
+                    _(
+                        "There is not enough balance in the customer's wallet"
+                        " to perform this payment. \n"
+                        " - Customer : %s\n"
+                        " - Customer Wallet : %s\n"
+                        " - Amount Payment : %s"
+                        % (
+                            payment.partner_id.display_name,
+                            payment.customer_wallet_balance,
+                            payment.amount,
+                        )
+                    )
+                )
+        return super().post()

--- a/account_customer_wallet/tests/common.py
+++ b/account_customer_wallet/tests/common.py
@@ -16,6 +16,7 @@ class TestBalance(SavepointCase):
         cls.customer_wallet_journal = cls.env.ref(
             "account_customer_wallet.account_journal_customer_wallet_demo"
         )
+        cls.payment_method = cls.env.ref("account.account_payment_method_manual_in")
         cls.cash_account = cls.env["account.account"].search(
             [("user_type_id.type", "=", "liquidity")], limit=1
         )
@@ -54,3 +55,19 @@ class TestBalance(SavepointCase):
                 ],
             }
         )
+
+    def _create_payment(self, amount=0, partner=None):
+        if partner is None:
+            partner = self.partner
+
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": partner.id,
+                "amount": amount,
+                "journal_id": self.customer_wallet_journal.id,
+                "payment_method_id": self.payment_method.id,
+            }
+        )
+        payment.post()

--- a/account_customer_wallet/tests/test_balance.py
+++ b/account_customer_wallet/tests/test_balance.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 
+from odoo.exceptions import UserError
+
 from .common import TestBalance
 
 
@@ -47,6 +49,17 @@ class TestAccountBalance(TestBalance):
         self._create_move(debit=50)
 
         self.assertEqual(self.partner.customer_wallet_balance, 50)
+
+    def test_payment(self):
+        """Prevent wallet to be negative, by blocking payments"""
+        self._create_move(credit=100)
+
+        # New balance will be 60 : OK
+        self._create_payment(amount=40)
+
+        # New balance will be -10 : should raise an error
+        with self.assertRaises(UserError):
+            self._create_payment(amount=70)
 
     def test_no_wallet_account(self):
         """If no wallet account is set, expect balances to be zero."""

--- a/account_customer_wallet/views/account_payment_views.xml
+++ b/account_customer_wallet/views/account_payment_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_payment_form" model="ir.ui.view">
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form" />
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="is_customer_wallet_journal" invisible="1" />
+                <field
+                    name="customer_wallet_balance"
+                    attrs="{'invisible': ['|', ('is_customer_wallet_journal', '=', False), ('partner_id', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_account_payment_invoice_form" model="ir.ui.view">
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_invoice_form" />
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="is_customer_wallet_journal" invisible="1" />
+                <field
+                    name="customer_wallet_balance"
+                    attrs="{'invisible': ['|', ('is_customer_wallet_journal', '=', False), ('partner_id', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Hi @carmenbianca.

i propose some changes in the ``account_customer_wallet`` to 
- cover the use case when a customer has a positive wallet and want to mark as paid a pending invoice.
- be able to prevent invoice payments with wallet if wallet balance is not enough.

![image](https://user-images.githubusercontent.com/3407482/164682607-6d487064-f53a-4059-b83a-840cede040dc.png)

![image](https://user-images.githubusercontent.com/3407482/164682674-59338ef9-46f2-496b-97ae-1bd19a287263.png)

**Note**
1) I have a local problem with pre-commit, so I disabled a test in the ``.pre-commit-config.yaml`` file. Iet me know when you want to merge this PR (if you want !) and I'll remove this commit. 
2) i changed the partner adress to a partner in the test. In fact, there is a problem in the computation of the wallet balance I think. As other "accounting" data, the wallet balance, should be at the parent partner level. 
given the following configuration : 
- parent partner A : 
- - partner Adress A1
- - partner Adress A2
if we credit debit A1 or A2, it should in my opinion recompute the wallet of the partner A.

![image](https://user-images.githubusercontent.com/3407482/164686249-c9d5feb7-5c03-425d-aab3-f9c6454782d7.png)
