### PR TITLE
[ADD] test to see if balance is commown between child and parent partner

### DIFF
--- a/account_customer_wallet/tests/test_balance.py
+++ b/account_customer_wallet/tests/test_balance.py
@@ -31,6 +31,18 @@ class TestAccountBalance(TestBalance):
 
         self.assertEqual(self.partner.customer_wallet_balance, -100)
 
+    def test_balance_to_parent(self):
+        """Credit child partner should impact parent partner balance"""
+        self._create_move(credit=1000)
+        self.assertEqual(self.partner.customer_wallet_balance, 1000)
+        self.assertEqual(self.partner.parent_id.customer_wallet_balance, 1000)
+
+    def test_balance_to_child(self):
+        """Credit parent partner should impact child partner balance"""
+        self._create_move(credit=2000, partner=self.partner.parent_id)
+        self.assertEqual(self.partner.customer_wallet_balance, 2000)
+        self.assertEqual(self.partner.parent_id.customer_wallet_balance, 2000)
+
     def test_different_partner(self):
         """Move lines for other partners do not affect the balances of all
         clients.

--- a/pos_customer_wallet/models/res_partner.py
+++ b/pos_customer_wallet/models/res_partner.py
@@ -14,15 +14,15 @@ class Partner(models.Model):
         if not self.ids:
             return True
 
-        all_partners_and_children = {}
+        all_partners_in_family = {}
         all_partner_ids = set()
         for partner in self:
-            all_partners_and_children[partner] = (
+            all_partners_in_family[partner] = (
                 self.with_context(active_test=False)
-                .search([("id", "child_of", partner.id)])
+                .search([("id", "child_of", partner.get_topmost_parent_id().id)])
                 .ids
             )
-            all_partner_ids |= set(all_partners_and_children[partner])
+            all_partner_ids |= set(all_partners_in_family[partner])
 
         # generate where clause to include multicompany rules
         where_query = account_bank_statement_line._where_calc(
@@ -47,7 +47,7 @@ class Partner(models.Model):
         )
         self.env.cr.execute(query, where_clause_params)
         totals = self.env.cr.dictfetchall()
-        for partner, child_ids in all_partners_and_children.items():
+        for partner, child_ids in all_partners_in_family.items():
             partner.customer_wallet_balance += sum(
                 -total["total"] for total in totals if total["partner_id"] in child_ids
             )


### PR DESCRIPTION
I just wrote a test, that is failing. But in fact, I don't know what should be the correct result !

**test_balance_to_parent** OK
if we credit the child, it credit the parent

**test_balance_to_child** KO
if we credit the parent it doesn't credit the child.

In fact, the same occures for  the ``invoice_total`` field in odoo / account core module. So it is consistent.

The use case I see is : 

partner : FAMILY NAME
partner address 1 : FAMILY NAME, John
partner address 2 : FAMILY NAME, Rebecca

- user make a credit by bank payment to "FAMILY NAME"
- accountant apply the payment to a "parent" partner

- John, or Rebecca make order in the PoS, the credit will not be applicable and the purchase will not be possible.

CC : @polchampion : an idea ? 