### PR TITLE
[ADD] mail_activity_filter_internal_user

### DIFF
--- a/mail_activity_filter_internal_user/__init__.py
+++ b/mail_activity_filter_internal_user/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+from . import models

--- a/mail_activity_filter_internal_user/__manifest__.py
+++ b/mail_activity_filter_internal_user/__manifest__.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+{
+    "name": "Mail Activity Filter Internal User",
+    "summary": """
+        Filter on internal user by default when assigning someone to an activity.""",
+    "version": "12.0.1.0.0",
+    "category": "Uncategorized",
+    "website": "https://coopiteasy.be",
+    "author": "Coop IT Easy SCRLfs",
+    "license": "AGPL-3",
+    "application": False,
+    "depends": ["mail"],
+    "excludes": [],
+    "data": [
+        "views/mail_activity.xml",
+    ],
+    "demo": [],
+    "qweb": [],
+}

--- a/mail_activity_filter_internal_user/models/__init__.py
+++ b/mail_activity_filter_internal_user/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_activity

--- a/mail_activity_filter_internal_user/models/mail_activity.py
+++ b/mail_activity_filter_internal_user/models/mail_activity.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class MailActivity(models.Model):
+
+    _inherit = "mail.activity"
+
+    filter_internal_user = fields.Boolean(
+        string="Assign to internal user only",
+        default=True,
+    )
+
+    @api.onchange("filter_internal_user")
+    def onchange_filter_internal_user(self):
+        """
+        Change the domain on the user_id field based on the value of
+        filter_internal_user.
+        """
+        if "user_id" in self._fields:
+            filter_internal_user_domain = ("share", "=", False)
+            previous_domain = self._fields["user_id"].domain
+            if self.filter_internal_user:
+                if filter_internal_user_domain not in previous_domain:
+                    previous_domain.append(filter_internal_user_domain)
+            else:
+                previous_domain.remove(filter_internal_user_domain)
+            return {"domain": {"user_id": previous_domain}}

--- a/mail_activity_filter_internal_user/readme/CONTRIBUTORS.rst
+++ b/mail_activity_filter_internal_user/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SCRLfs <https://coopiteasy.be>`_:
+
+  * Rémy Taymans

--- a/mail_activity_filter_internal_user/readme/DESCRIPTION.rst
+++ b/mail_activity_filter_internal_user/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Add a field to filter on internal user when assigning someone to an activity.

--- a/mail_activity_filter_internal_user/readme/newsfragments/1.feature.rst
+++ b/mail_activity_filter_internal_user/readme/newsfragments/1.feature.rst
@@ -1,0 +1,1 @@
+Allow to schedule activity on internal users by default instead of all users.

--- a/mail_activity_filter_internal_user/views/mail_activity.xml
+++ b/mail_activity_filter_internal_user/views/mail_activity.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="mail_activity_view_form_popup">
+        <field name="name">mail.activity.view.form.popup</field>
+        <field name="model">mail.activity</field>
+        <field name="inherit_id" ref="mail.mail_activity_view_form_popup" />
+        <field name="arch" type="xml">
+            <field name="user_id" position="before">
+                <field name="filter_internal_user" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/mail_activity_filter_internal_user/odoo/addons/mail_activity_filter_internal_user
+++ b/setup/mail_activity_filter_internal_user/odoo/addons/mail_activity_filter_internal_user
@@ -1,0 +1,1 @@
+../../../../mail_activity_filter_internal_user

--- a/setup/mail_activity_filter_internal_user/setup.py
+++ b/setup/mail_activity_filter_internal_user/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## Description

Allow to schedule activity on internal users by default instead of all users.

I think it can be moved to OCA but maybe the name of the module is not good and also I don't know where to put it in OCA.

## Odoo task (if applicable)

[task](https://gestion.coopiteasy.be/web#id=8462&action=479&model=project.task&view_type=form&menu_id=536)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] (If a new module) Moving this to OCA has been considered.
