### PR TITLE
[FIX] pos_customer_wallet: Partner form should not break for users wi…

### DIFF
--- a/pos_customer_wallet/models/res_partner.py
+++ b/pos_customer_wallet/models/res_partner.py
@@ -10,7 +10,7 @@ class Partner(models.Model):
     def _compute_customer_wallet_balance(self):
         super()._compute_customer_wallet_balance()
 
-        account_bank_statement_line = self.env["account.bank.statement.line"]
+        account_bank_statement_line = self.env["account.bank.statement.line"].sudo()
         if not self.ids:
             return True
 


### PR DESCRIPTION
…thout perms

Previously there was a permission error on trying to read the
`account.bank.statement.line` model.

Signed-off-by: Carmen Bianca Bakker <carmen@coopiteasy.be>

## Description

Initially submitted here: https://github.com/coopiteasy/account-payment/pull/1

## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=8611&model=project.task&view_type=form&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
