### PR TITLE
[FIX] prevent global domain variable modification

### DIFF
--- a/mail_activity_filter_internal_user/models/mail_activity.py
+++ b/mail_activity_filter_internal_user/models/mail_activity.py
@@ -19,12 +19,8 @@ class MailActivity(models.Model):
         Change the domain on the user_id field based on the value of
         filter_internal_user.
         """
-        if "user_id" in self._fields:
-            filter_internal_user_domain = ("share", "=", False)
-            previous_domain = self._fields["user_id"].domain
-            if self.filter_internal_user:
-                if filter_internal_user_domain not in previous_domain:
-                    previous_domain.append(filter_internal_user_domain)
-            else:
-                previous_domain.remove(filter_internal_user_domain)
-            return {"domain": {"user_id": previous_domain}}
+        # copy to ensure original domain is not modified
+        user_domain = self._fields["user_id"].domain.copy()
+        if self.filter_internal_user:
+            user_domain.append(("share", "=", False))
+        return {"domain": {"user_id": user_domain}}


### PR DESCRIPTION
## description

fix `mail_activity_filter_internal_user`: don't modify the original domain property of the mail.activity.user_id. its initial value is the default empty list defined in the odoo.fields._Relational class, and is thus shared by all fields with a default domain. modifying this variable causes all of these fields to have their domain modified, across all databases.

## odoo task

[t5760](https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=8462)