### PR TITLE
[FIX] fix available delivery carriers

### DIFF
--- a/delivery_product_restriction/models/delivery_carrier.py
+++ b/delivery_product_restriction/models/delivery_carrier.py
@@ -18,17 +18,14 @@ class DeliveryCarrier(models.Model):
 
     def available_carriers(self, partner, products=None):
         """
-        Overwrite the `available_carriers` function in the
+        Override the `available_carriers` function in the
         delivery.carrier in the delivery module.
 
         Returns a recordset of the available delivery carrier given the
         partner location and the authorised carrier for the products.
         """
-        delivery_carriers = self
-        if partner:
-            delivery_carriers = delivery_carriers.filtered(
-                lambda c: c._match_address(partner)
-            )
+        # the default behavior is to filter by the address of the partner.
+        delivery_carriers = super().available_carriers(partner)
         if products:
             delivery_carriers = delivery_carriers.filtered(
                 lambda c: c._can_be_used_to_deliver_products(products)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,7 @@
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_base
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_product
+git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/member_card
+git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/eater
+git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/eater_member_card
+# Terrible workaround. Dependency of beesdoo_base.
+git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/company_supplier_context


### PR DESCRIPTION
## description

call `super()` instead of re-implementing the default logic, to ensure that other modules can also override it (like `delivery_multi_destination` for instance).

## odoo task

[task](https://gestion.coopiteasy.be/web#id=8928&model=project.task&view_type=form)