### PR TITLE
[12.0][FIX] make company_today cron run once a day

### DIFF
--- a/company_today/data/ir_cron.xml
+++ b/company_today/data/ir_cron.xml
@@ -5,18 +5,20 @@ SPDX-FileCopyrightText: 2022 Coop IT Easy SC
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <odoo>
-    <record id="compute_today" model="ir.cron">
-        <field name="name">Set today's date on the company</field>
-        <field name="model_id" ref="model_res_company" />
-        <field name="code">model.cron_update_today()</field>
-        <field name="interval_number">1</field>
-        <field name="interval_type">days</field>
-        <field
-            name="nextcall"
-            eval="(datetime.now() + timedelta(days=1))
-            .replace(hour=0, minute=0, second=0, microsecond=0)"
-        />
-        <field name="numbercall">-1</field>
-        <field name="doall">1</field>
-    </record>
+    <data noupdate="1">
+        <record id="compute_today" model="ir.cron">
+            <field name="name">Set today's date on the company</field>
+            <field name="model_id" ref="model_res_company" />
+            <field name="code">model.cron_update_today()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field
+                name="nextcall"
+                eval="(datetime.now() + timedelta(days=1))
+                .replace(hour=0, minute=0, second=0, microsecond=0)"
+            />
+            <field name="numbercall">-1</field>
+            <field name="doall">1</field>
+        </record>
+    </data>
 </odoo>

--- a/company_today/data/ir_cron.xml
+++ b/company_today/data/ir_cron.xml
@@ -9,9 +9,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <field name="name">Set today's date on the company</field>
         <field name="model_id" ref="model_res_company" />
         <field name="code">model.cron_update_today()</field>
-        <field name="active" eval="True" />
         <field name="interval_number">1</field>
-        <field name="interval_type">minutes</field>
+        <field name="interval_type">days</field>
+        <field
+            name="nextcall"
+            eval="(datetime.now() + timedelta(days=1))
+            .replace(hour=0, minute=0, second=0, microsecond=0)"
+        />
         <field name="numbercall">-1</field>
         <field name="doall">1</field>
     </record>


### PR DESCRIPTION
## description

make `company_today` cron run once a day at 00:00:00 utc instead of every minute, to avoid recomputing fields that depend on it over and over uselessly. odoo handles all time-related data in utc, so running it more than once after midnight (utc) does not change anything.

also set the cron `noupdate` so it can be customized by users without being overwritten at the next update.

## odoo task

[t9911](https://gestion.coopiteasy.be/web#id=9903&model=project.task)