### PR TITLE
[12.0][REM] dependency to beesdoo_product

### DIFF
--- a/website_sale_detailed_product_description/__manifest__.py
+++ b/website_sale_detailed_product_description/__manifest__.py
@@ -9,6 +9,6 @@
     "category": "Website",
     "version": "12.0.1.0.0",
     "license": "AGPL-3",
-    "depends": ["beesdoo_product", "website_sale"],
+    "depends": ["website_sale"],
     "data": ["views/product_views.xml", "views/website_sale_template.xml"],
 }


### PR DESCRIPTION
The module website_sale_detailed_product_description depends on beesdoo_product, which is deprecated. Besides I don't see any dependency to the modules that were splitted from beesdoo_product. 
We need to remove this dependency to safely uninstall beesdoo_product from databases.