### PR TITLE
[FIX] account_customer_wallet: Prevent error when creating partner

### DIFF
--- a/account_customer_wallet/models/res_partner.py
+++ b/account_customer_wallet/models/res_partner.py
@@ -15,6 +15,7 @@ class Partner(models.Model):
         readonly=True,
         recursive=True,
         search="_search_customer_wallet_balance",
+        default=0,
     )
     account_move_line_ids = fields.One2many(
         comodel_name="account.move.line",


### PR DESCRIPTION

## Description

In Odoo 16, it is mandatory to provide a value for computed fields. If you don't, the creation of NewId objects results in error 'Compute method failed to assign res.partner(<NewId
...>,).customer_wallet_balance'.


## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=11080&action=475&active_id=264&model=project.task&view_type=form&menu_id=536

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
