### PR TITLE
[16.0][REF] resource_work_time_from_contracts: remove readonly

### DIFF
--- a/resource_work_time_from_contracts/models/resource_calendar_leaves.py
+++ b/resource_work_time_from_contracts/models/resource_calendar_leaves.py
@@ -13,6 +13,9 @@ class ResourceCalendarLeaves(models.Model):
     # leaves for all resources are defined in the same resource calendar,
     # which is needed to compute working hours while taking leaves into
     # account.
+    # fixme A readonly related field without an inverse method should not have a
+    #      default value, as it does not make sense.
+    #      cf odoo/odoo/fields.py:626
     calendar_id = fields.Many2one(
         "resource.calendar",
         related="resource_id.calendar_id",

--- a/resource_work_time_from_contracts/models/resource_mixin.py
+++ b/resource_work_time_from_contracts/models/resource_mixin.py
@@ -16,8 +16,7 @@ class ResourceMixin(models.AbstractModel):
 
     _inherit = "resource.mixin"
 
-    # make this field read-only.
-    resource_calendar_id = fields.Many2one("resource.calendar", readonly=True)
+    resource_calendar_id = fields.Many2one("resource.calendar")
 
     def list_work_time_per_day(
         self,

--- a/resource_work_time_from_contracts/models/resource_mixin.py
+++ b/resource_work_time_from_contracts/models/resource_mixin.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from pytz import timezone, utc
 
-from odoo import fields, models
+from odoo import models
 from odoo.tools import float_utils
 
 from odoo.addons.resource.models.resource import ROUNDING_FACTOR
@@ -15,8 +15,6 @@ from odoo.addons.resource.models.resource import ROUNDING_FACTOR
 class ResourceMixin(models.AbstractModel):
 
     _inherit = "resource.mixin"
-
-    resource_calendar_id = fields.Many2one("resource.calendar")
 
     def list_work_time_per_day(
         self,

--- a/resource_work_time_from_contracts/models/resource_resource.py
+++ b/resource_work_time_from_contracts/models/resource_resource.py
@@ -9,6 +9,10 @@ class ResourceResource(models.Model):
     _inherit = "resource.resource"
 
     # force this field to be equal to the resource_calendar_id of the company.
+    # fixme A readonly related field without an inverse method should not have a
+    #      default value, as it does not make sense.
+    #      cf odoo/odoo/fields.py:626
+
     calendar_id = fields.Many2one(
         "resource.calendar",
         related="company_id.resource_calendar_id",


### PR DESCRIPTION
This line has the side effect of issuing a warning for all models inheriting resource.mixin and setting defaults to resource_calendar_id.

The readonly was introduced to prevent modifications by the user since the modules computes it. It is however to relevant since the field is hidden (readonly parameter only affects the views).

fixes https://github.com/coopiteasy/addons/issues/311