### PR TITLE
[FIX] resource_multi_week_work_time_from_contracts: Handle case where there is no calendar

### DIFF
--- a/resource_multi_week_work_time_from_contracts/models/resource_mixin.py
+++ b/resource_multi_week_work_time_from_contracts/models/resource_mixin.py
@@ -10,4 +10,6 @@ class ResourceMixing(models.AbstractModel):
 
     def get_calendar_for_date(self, date):
         calendar = super().get_calendar_for_date(date)
-        return calendar._get_multi_week_calendar(day=date)
+        if calendar is not None:
+            calendar = calendar._get_multi_week_calendar(day=date)
+        return calendar


### PR DESCRIPTION

## Description

The upstream get_calendar_for_date can return None. We should respect that.




## Odoo task (if applicable)



## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
