### PR TITLE
[FIX] website_sale_product_contract_gift: "copy" in name

### DIFF
--- a/website_sale_product_contract_gift/models/sale_order.py
+++ b/website_sale_product_contract_gift/models/sale_order.py
@@ -94,13 +94,24 @@ class SaleOrder(models.Model):
             if existing_partners:
                 contract_partner = existing_partners[0]
             else:
-                contract_partner = order.partner_shipping_id.copy(
+                # We prefer that the contract owner be a 'contact'
+                # partner rather than a 'delivery' partner. Granting
+                # the delivery partner access to e-commerce can cause
+                # issues in terms of invoicing.
+                contract_partner = self.env["res.partner"].create(
                     {
-                        # copy name to prevent odoo adding '(copy)'
-                        # after the name.
                         "name": order.partner_shipping_id.name,
                         "type": "contact",
                         "parent_id": False,
+                        "email": order.partner_shipping_id.email,
+                        "phone": order.partner_shipping_id.phone,
+                        "mobile": order.partner_shipping_id.mobile,
+                        "street": order.partner_shipping_id.street,
+                        "street2": order.partner_shipping_id.street2,
+                        "zip": order.partner_shipping_id.zip,
+                        "city": order.partner_shipping_id.city,
+                        "state_id": order.partner_shipping_id.state_id.id,
+                        "country_id": order.partner_shipping_id.country_id.id,
                     }
                 )
             for line in line_to_create_contract:


### PR DESCRIPTION
## Description

When using module "partner_firstname", the copy() method adds a "(copy)" string to the firstname. Even if writing the name when copying.

Also when copying all fields are copied, and in this case we want only the fields that are filled in the form on the website.

So using create() is better than copy() for this case.

## Odoo task (if applicable)

[task](https://gestion.coopiteasy.be/web#id=14017&model=project.task&view_type=form&menu_id=536)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
