### PR TITLE
[16.0][FIX] set bank account on commercial_partner_id

### DIFF
--- a/payment_sepa_dd/models/payment_transaction.py
+++ b/payment_sepa_dd/models/payment_transaction.py
@@ -170,7 +170,7 @@ class PaymentTransaction(models.Model):
             if not res_partner_bank:
                 res_partner_bank = self.env["res.partner.bank"].create(
                     {
-                        "partner_id": tx.partner_id.id,
+                        "partner_id": tx.partner_id.commercial_partner_id.id,
                         "acc_number": tx.sepa_dd_iban,
                     }
                 )

--- a/payment_sepa_dd/models/payment_transaction.py
+++ b/payment_sepa_dd/models/payment_transaction.py
@@ -168,9 +168,17 @@ class PaymentTransaction(models.Model):
         for tx in self:
             res_partner_bank = tx.get_res_partner_bank()
             if not res_partner_bank:
+                # force parent company creation to attach the bank account to it
+                partner = tx.partner_id
+                if (
+                    not partner.parent_id
+                    and not partner.is_company
+                    and partner.company_name
+                ):
+                    partner.create_company()
                 res_partner_bank = self.env["res.partner.bank"].create(
                     {
-                        "partner_id": tx.partner_id.commercial_partner_id.id,
+                        "partner_id": partner.commercial_partner_id.id,
                         "acc_number": tx.sepa_dd_iban,
                     }
                 )


### PR DESCRIPTION
Set bank account on commercial_partner_id so that it is set on the company when the order is made in the name of a company.
It is the company that is invoiced (if the company partner exists). The mandate is related to the bank account, and we need a mandate to invoice the company via SEPA. So the mandate should be linked to the company, not the partner.

## Description



## Odoo task (if applicable)



## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
