### PR TITLE
[16.0][FIX] remove link between gift receiver address from the giver.

### DIFF
--- a/website_sale_product_contract_gift/models/sale_order.py
+++ b/website_sale_product_contract_gift/models/sale_order.py
@@ -91,29 +91,29 @@ class SaleOrder(models.Model):
                 )
             )
             existing_partners = self.find_contact_partners(order.partner_shipping_id)
-            if existing_partners:
+            if existing_partners and order.partner_shipping_id != existing_partners:
+                # We move the shipping address provided by the donor
+                # to the receiver. The address on the receiver and the
+                # one given by the donor can differ. In such case, and
+                # when the receiver has an ongoing subscription, the
+                # address of the receiver for all its contract will
+                # change to the address given by the donor. This can
+                # be wrong. But offering a subscription to someone
+                # already subscribed AND filling the wrong address is
+                # quite rare. Besides, the old address is kept on the
+                # receiver. So the error is easy to fix.
                 contract_partner = existing_partners[0]
+                order.partner_shipping_id.parent_id = contract_partner
+
             else:
                 # We prefer that the contract owner be a 'contact'
                 # partner rather than a 'delivery' partner. Granting
                 # the delivery partner access to e-commerce can cause
                 # issues in terms of invoicing.
-                contract_partner = self.env["res.partner"].create(
-                    {
-                        "name": order.partner_shipping_id.name,
-                        "type": "contact",
-                        "parent_id": False,
-                        "email": order.partner_shipping_id.email,
-                        "phone": order.partner_shipping_id.phone,
-                        "mobile": order.partner_shipping_id.mobile,
-                        "street": order.partner_shipping_id.street,
-                        "street2": order.partner_shipping_id.street2,
-                        "zip": order.partner_shipping_id.zip,
-                        "city": order.partner_shipping_id.city,
-                        "state_id": order.partner_shipping_id.state_id.id,
-                        "country_id": order.partner_shipping_id.country_id.id,
-                    }
-                )
+                order.partner_shipping_id.parent_id = False
+                order.partner_shipping_id.type = "contact"
+                contract_partner = order.partner_shipping_id
+
             for line in line_to_create_contract:
                 date_start = line.date_start
                 try:

--- a/website_sale_product_contract_gift/tests/test_gift.py
+++ b/website_sale_product_contract_gift/tests/test_gift.py
@@ -64,12 +64,24 @@ class TestGiftContract(TestGiftContractBase):
             self.assertEqual(line.recurring_rule_type, "yearly")
             self.assertEqual(line.recurring_interval, 1)
 
-    def test_gift_contract_partner(self):
+    def test_gift_contract_partner_with_existing_partner(self):
+        existing_partner = self.env["res.partner"].create(
+            {
+                "name": "partner gift to existing partner",
+                "email": "partner_gift_to@test.com",
+                "type": "contact",
+            }
+        )
         contract = self._generate_contract_from_order()
         assert contract.partner_id.id != self.partner_gift_to.id
-        assert contract.partner_id.name == self.partner_gift_to.name
-        assert contract.partner_id.email == self.partner_gift_to.email
-        assert contract.partner_id.street == self.partner_gift_to.street
+        assert contract.partner_id.id == existing_partner.id
+        assert self.partner_gift_to.parent_id == existing_partner
+        assert contract.partner_id.type == "contact"
+
+    def test_gift_contract_partner_without_existing_partner(self):
+        contract = self._generate_contract_from_order()
+        assert contract.partner_id.id == self.partner_gift_to.id
+        self.assertFalse(self.partner_gift_to.parent_id.id)
         assert contract.partner_id.type == "contact"
 
     def test_gift_contract_is_gift(self):


### PR DESCRIPTION
Adding receiver address as a delivery address changed the delivery address for the current subscriptions of the gift giver. Now the receiver address is unlinked from the giver at SO confirmation.

## Description



## Odoo task (if applicable)
https://gestion.coopiteasy.be/web#id=14548&model=project.task&view_type=form&menu_id=


## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
