### PR TITLE
[16.0][FIX] web access should be removed when contract is archived

### DIFF
--- a/subscription_web_access/models/res_partner.py
+++ b/subscription_web_access/models/res_partner.py
@@ -21,6 +21,7 @@ class ResPartner(models.Model):
     # non-stored computed field that depends on the current date. this is why
     # it is also called everyday from a cron job.
     @api.depends(
+        "contract_ids.active",
         "contract_ids.contract_line_ids.state",
         "contract_ids.contract_line_ids.product_id.is_trial",
     )


### PR DESCRIPTION
## Description
Web access (field on the partner used for external API request), should be updated when the customer's contract is archived or unarchived. 


## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=14714&action=475&active_id=605&model=project.task&view_type=form&menu_id=536

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
