### PR TITLE
[16.0][FIX] payment_sepa_dd:  partner creation

### DIFF
--- a/payment_sepa_dd/models/payment_transaction.py
+++ b/payment_sepa_dd/models/payment_transaction.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 
-from odoo import _, api, fields, models
+from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import ValidationError
 
 from odoo.addons.base.models.res_bank import sanitize_account_number
@@ -117,7 +117,7 @@ class PaymentTransaction(models.Model):
         """Create mandate when transaction is set as pending"""
         txs_to_process = super()._set_pending(state_message=state_message)
         if self.provider_code == "sepa_dd":
-            txs_to_process.create_sepa_dd_mandate()
+            txs_to_process._create_sepa_dd_mandate()
         return txs_to_process
 
     # Constrains
@@ -164,7 +164,7 @@ class PaymentTransaction(models.Model):
             "state": "valid",
         }
 
-    def create_sepa_dd_mandate(self):
+    def _create_sepa_dd_mandate(self):
         for tx in self:
             res_partner_bank = tx.get_res_partner_bank()
             if not res_partner_bank:
@@ -175,7 +175,13 @@ class PaymentTransaction(models.Model):
                     and not partner.is_company
                     and partner.company_name
                 ):
-                    partner.create_company()
+                    # the following statement cannot be performed by
+                    # sudo(), because res.partner has a flag
+                    # _allow_sudo_commands = False
+                    # We trick the environment to perform this action
+                    new_env = partner.env(user=SUPERUSER_ID)
+                    new_env.uid_origin = SUPERUSER_ID
+                    partner.with_env(new_env).create_company()
                 res_partner_bank = self.env["res.partner.bank"].create(
                     {
                         "partner_id": partner.commercial_partner_id.id,


### PR DESCRIPTION
## Description

Using create_company() generate a ACL error.
    
Even with sudo() this does not work because of the _allow_sudo_commands
variable that is set to false on res.partner.
    
We need to trick the environment to achieve running this.


## Odoo task (if applicable)

[task](https://gestion.coopiteasy.be/web#id=14837&action=479&model=project.task&view_type=form&menu_id=536)

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
