### PR TITLE
[12.0][FIX] product_label_report: remove obsolete report

### DIFF
--- a/product_label_report/report/product_reports.xml
+++ b/product_label_report/report/product_reports.xml
@@ -74,17 +74,4 @@
         file="product_label_report.product_label.xml"
     />
 
-
-
-
-  <report
-        id="report_product_template_label"
-        string="Products Labels"
-        model="product.template"
-        report_type="qweb-pdf"
-        paperformat="paperformat_a4_nomargin"
-        name="product_label_report.report_producttemplatelabel"
-        file="product_label_report.product_template_templates.xml"
-    />
-
 </odoo>


### PR DESCRIPTION
## description

remove obsolete report left there by mistake during the refactoring of 2020-06-11. `report_producttemplatelabel` has been replaced by `report_product_label_8x3`.

## odoo task

[t16751](https://gestion.coopiteasy.be/web#id=16751&model=project.task)