### PR TITLE
[16.0][FIX] product_label_report: remove obsolete label template

### DIFF
--- a/product_label_report/report/product_label.xml
+++ b/product_label_report/report/product_label.xml
@@ -71,25 +71,4 @@
             </div>
         </t>
     </template>
-
-    <!-- BUG: product_label_report.report_style not found -->
-    <!-- <template id="report_producttemplatelabel">
-        <t t-call="web.html_container">
-        <t t-set="data_report_dpi" t-value="300" />
-        <div class="page">
-            <t t-call="product_label_report.report_style" />
-            <t t-foreach="docs" t-as="product">
-            <div class="col-xs-4">
-                <img
-                            t-if="product.barcode"
-                            t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', product.barcode, 600, 150)"
-                            class="barcode-img"
-                        />
-                <span t-field="product.barcode" class="barcode" />
-                <div class="product-name" t-out="product.name" />
-            </div>
-            </t>
-        </div>
-        </t>
-    </template> -->
 </odoo>

--- a/product_label_report/report/product_reports.xml
+++ b/product_label_report/report/product_reports.xml
@@ -28,58 +28,61 @@
     </record>
 
     <record id="product_template_label_8x3" model="ir.actions.report">
-		<field name="name">Product Labels 8x3</field>
-		<field name="model">product.template</field>
-		<field name="report_type">qweb-pdf</field>
-		<field name="paperformat_id" ref="paperformat_a4_nomargin" />
-		<field name="report_name">product_label_report.report_product_label_8x3</field>
-		<field name="report_file">product_label_report.product_label</field>
-		<field name="binding_model_id" ref="product.model_product_template" />
-		<field name="binding_type">report</field>
+        <field name="name">Product Labels 8x3</field>
+        <field name="model">product.template</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="paperformat_id" ref="paperformat_a4_nomargin" />
+        <field name="report_name">product_label_report.report_product_label_8x3</field>
+        <field name="report_file">product_label_report.product_label</field>
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_type">report</field>
     </record>
 
     <record id="product_template_label_repeat_10x4" model="ir.actions.report">
-		<field name="name">Same Product Labels 10x4</field>
-		<field name="model">product.template</field>
-		<field name="report_type">qweb-pdf</field>
-		<field name="paperformat_id" ref="paperformat_a4_nomargin" />
-		<field name="report_name">product_label_report.report_same_product_label_10x4</field>
-		<field name="report_file">product_label_report.same_product_label</field>
-		<field name="binding_model_id" ref="product.model_product_template" />
-		<field name="binding_type">report</field>
+        <field name="name">Same Product Labels 10x4</field>
+        <field name="model">product.template</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="paperformat_id" ref="paperformat_a4_nomargin" />
+        <field
+            name="report_name"
+        >product_label_report.report_same_product_label_10x4</field>
+        <field name="report_file">product_label_report.same_product_label</field>
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_type">report</field>
     </record>
 
     <record id="product_template_label_10x4" model="ir.actions.report">
-		<field name="name">Product Labels 10x4</field>
-		<field name="model">product.template</field>
-		<field name="report_type">qweb-pdf</field>
-		<field name="paperformat_id" ref="paperformat_a4_nomargin" />
-		<field name="report_name">product_label_report.report_product_label_10x4</field>
-		<field name="report_file">product_label_report.product_label</field>
-		<field name="binding_model_id" ref="product.model_product_template" />
-		<field name="binding_type">report</field>
+        <field name="name">Product Labels 10x4</field>
+        <field name="model">product.template</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="paperformat_id" ref="paperformat_a4_nomargin" />
+        <field name="report_name">product_label_report.report_product_label_10x4</field>
+        <field name="report_file">product_label_report.product_label</field>
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_type">report</field>
     </record>
 
     <record id="product_template_label_repeat_13x5" model="ir.actions.report">
-		<field name="name">Same Product Labels 13x5</field>
-		<field name="model">product.template</field>
-		<field name="report_type">qweb-pdf</field>
-		<field name="paperformat_id" ref="paperformat_a4_nomargin" />
-		<field name="report_name">product_label_report.report_same_product_label_13x5</field>
-		<field name="report_file">product_label_report.same_product_label</field>
-		<field name="binding_model_id" ref="product.model_product_template" />
-		<field name="binding_type">report</field>
+        <field name="name">Same Product Labels 13x5</field>
+        <field name="model">product.template</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="paperformat_id" ref="paperformat_a4_nomargin" />
+        <field
+            name="report_name"
+        >product_label_report.report_same_product_label_13x5</field>
+        <field name="report_file">product_label_report.same_product_label</field>
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_type">report</field>
     </record>
 
     <record id="product_template_label_13x5" model="ir.actions.report">
-		<field name="name">Product Labels 13x5</field>
-		<field name="model">product.template</field>
-		<field name="report_type">qweb-pdf</field>
-		<field name="paperformat_id" ref="paperformat_a4_nomargin" />
-		<field name="report_name">product_label_report.report_product_label_13x5</field>
-		<field name="report_file">product_label_report.product_label</field>
-		<field name="binding_model_id" ref="product.model_product_template" />
-		<field name="binding_type">report</field>
+        <field name="name">Product Labels 13x5</field>
+        <field name="model">product.template</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="paperformat_id" ref="paperformat_a4_nomargin" />
+        <field name="report_name">product_label_report.report_product_label_13x5</field>
+        <field name="report_file">product_label_report.product_label</field>
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_type">report</field>
     </record>
-
 </odoo>


### PR DESCRIPTION
## description

*   remove obsolete label template: `report_producttemplatelabel` has been replaced by `report_product_label_8x3` (see also #405).
*   replace tabs by spaces in reports xml file.

## odoo task

[t16751](https://gestion.coopiteasy.be/web#id=16751&model=project.task)